### PR TITLE
Refactor so that StateUpdater doesn't need pages

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -20,6 +20,7 @@ import { StateTransitionCollector } from './core/collectors/StateTransitionColle
 import { UserRegistrationCollector } from './core/collectors/UserRegistrationCollector'
 import { VerifierCollector } from './core/collectors/VerifierCollector'
 import { DataSyncService } from './core/DataSyncService'
+import { OnChainDataCollector } from './core/OnChainDataCollector'
 import { StateUpdater } from './core/StateUpdater'
 import { StatusService } from './core/StatusService'
 import { BlockDownloader } from './core/sync/BlockDownloader'
@@ -133,7 +134,6 @@ export class Application {
       config.contracts.perpetual
     )
     const stateUpdater = new StateUpdater(
-      pageRepository,
       stateUpdateRepository,
       rollupStateRepository,
       ethereumClient,
@@ -159,7 +159,7 @@ export class Application {
       config.contracts.perpetual
     )
 
-    const dataSyncService = new DataSyncService(
+    const onChainDataCollector = new OnChainDataCollector(
       verifierCollector,
       pageMappingCollector,
       pageCollector,
@@ -168,8 +168,15 @@ export class Application {
       userRegistrationCollector,
       forcedEventsCollector,
       finalizeExitEventsCollector,
+      pageRepository,
       logger
     )
+
+    const dataSyncService = new DataSyncService(
+      onChainDataCollector,
+      stateUpdater
+    )
+
     const syncScheduler = new SyncScheduler(
       syncStatusRepository,
       blockDownloader,

--- a/packages/backend/src/core/DataCollector.ts
+++ b/packages/backend/src/core/DataCollector.ts
@@ -1,0 +1,8 @@
+import { BlockRange } from '../model'
+import { BlockNumber } from '../peripherals/ethereum/types'
+import { StateTransition } from './StateUpdater'
+
+export interface IDataCollector {
+  collect(blockRange: BlockRange): Promise<StateTransition[]>
+  discardAfter(blockNumber: BlockNumber): Promise<void>
+}

--- a/packages/backend/src/core/DataSyncService.ts
+++ b/packages/backend/src/core/DataSyncService.ts
@@ -1,71 +1,23 @@
 import { BlockRange } from '../model'
 import { BlockNumber } from '../peripherals/ethereum/types'
-import { Logger } from '../tools/Logger'
-import { FinalizeExitEventsCollector } from './collectors/FinalizeExitEventsCollector'
-import { ForcedEventsCollector } from './collectors/ForcedEventsCollector'
-import { PageCollector } from './collectors/PageCollector'
-import { PageMappingCollector } from './collectors/PageMappingCollector'
-import { StateTransitionCollector } from './collectors/StateTransitionCollector'
-import { UserRegistrationCollector } from './collectors/UserRegistrationCollector'
-import { VerifierCollector } from './collectors/VerifierCollector'
+import { IDataCollector } from './DataCollector'
 import { StateUpdater } from './StateUpdater'
 
 export class DataSyncService {
   constructor(
-    private readonly verifierCollector: VerifierCollector,
-    private readonly pageMappingCollector: PageMappingCollector,
-    private readonly pageCollector: PageCollector,
-    private readonly stateTransitionCollector: StateTransitionCollector,
-    private readonly stateUpdater: StateUpdater,
-    private readonly userRegistrationCollector: UserRegistrationCollector,
-    private readonly forcedEventsCollector: ForcedEventsCollector,
-    private readonly finalizeExitEventsCollector: FinalizeExitEventsCollector,
-    private readonly logger: Logger
-  ) {
-    this.logger = logger.for(this)
-  }
+    private readonly dataCollector: IDataCollector,
+    private readonly stateUpdater: StateUpdater
+  ) {}
 
   async sync(blockRange: BlockRange) {
-    const verifiers = await this.verifierCollector.collect(blockRange)
+    const stateTransitions = await this.dataCollector.collect(blockRange)
 
-    const pages = await this.pageCollector.collect(blockRange)
-    const pageMappings = await this.pageMappingCollector.collect(
-      blockRange,
-      verifiers
-    )
-    const stateTransitions = await this.stateTransitionCollector.collect(
-      blockRange
-    )
-
-    const userRegistrations = await this.userRegistrationCollector.collect(
-      blockRange
-    )
-    const forcedEvents = await this.forcedEventsCollector.collect(blockRange)
-    const finalizeExitEvents = await this.finalizeExitEventsCollector.collect(
-      blockRange
-    )
-
-    this.logger.info({
-      method: 'sync',
-      blockRange: { from: blockRange.start, to: blockRange.end },
-      verifiers: verifiers.length,
-      pages: pages.length,
-      pageMappings: pageMappings.length,
-      stateTransitions: stateTransitions.length,
-      userRegistrations: userRegistrations.length,
-      forcedEvents,
-      finalizeExitEvents,
-    })
-
-    await this.stateUpdater.save(stateTransitions)
+    for (const stateTransition of stateTransitions) {
+      await this.stateUpdater.processStateTransition(stateTransition)
+    }
   }
 
   async discardAfter(blockNumber: BlockNumber) {
-    await this.verifierCollector.discardAfter(blockNumber)
-    await this.pageMappingCollector.discardAfter(blockNumber)
-    await this.pageCollector.discardAfter(blockNumber)
-    await this.stateTransitionCollector.discardAfter(blockNumber)
-    await this.stateUpdater.discardAfter(blockNumber)
-    await this.userRegistrationCollector.discardAfter(blockNumber)
+    await this.dataCollector.discardAfter(blockNumber)
   }
 }

--- a/packages/backend/src/core/OnChainDataCollector.ts
+++ b/packages/backend/src/core/OnChainDataCollector.ts
@@ -1,0 +1,117 @@
+import { decodeOnChainData } from '@explorer/encoding'
+
+import { BlockRange } from '../model'
+import { PageRepository } from '../peripherals/database/PageRepository'
+import { StateTransitionRecord } from '../peripherals/database/StateTransitionRepository'
+import { BlockNumber } from '../peripherals/ethereum/types'
+import { Logger } from '../tools/Logger'
+import { FinalizeExitEventsCollector } from './collectors/FinalizeExitEventsCollector'
+import { ForcedEventsCollector } from './collectors/ForcedEventsCollector'
+import { PageCollector } from './collectors/PageCollector'
+import { PageMappingCollector } from './collectors/PageMappingCollector'
+import { StateTransitionCollector } from './collectors/StateTransitionCollector'
+import { UserRegistrationCollector } from './collectors/UserRegistrationCollector'
+import { VerifierCollector } from './collectors/VerifierCollector'
+import { IDataCollector } from './DataCollector'
+import { StateTransition, StateUpdater } from './StateUpdater'
+
+export class OnChainDataCollector implements IDataCollector {
+  constructor(
+    private readonly verifierCollector: VerifierCollector,
+    private readonly pageMappingCollector: PageMappingCollector,
+    private readonly pageCollector: PageCollector,
+    private readonly stateTransitionCollector: StateTransitionCollector,
+    private readonly stateUpdater: StateUpdater,
+    private readonly userRegistrationCollector: UserRegistrationCollector,
+    private readonly forcedEventsCollector: ForcedEventsCollector,
+    private readonly finalizeExitEventsCollector: FinalizeExitEventsCollector,
+    private readonly pageRepository: PageRepository,
+    private readonly logger: Logger
+  ) {
+    this.logger = logger.for(this)
+  }
+
+  async collect(blockRange: BlockRange): Promise<StateTransition[]> {
+    const verifiers = await this.verifierCollector.collect(blockRange)
+
+    const pages = await this.pageCollector.collect(blockRange)
+    const pageMappings = await this.pageMappingCollector.collect(
+      blockRange,
+      verifiers
+    )
+    const stateTransitions = await this.stateTransitionCollector.collect(
+      blockRange
+    )
+
+    const userRegistrations = await this.userRegistrationCollector.collect(
+      blockRange
+    )
+    const forcedEvents = await this.forcedEventsCollector.collect(blockRange)
+    const finalizeExitEvents = await this.finalizeExitEventsCollector.collect(
+      blockRange
+    )
+
+    this.logger.info({
+      method: 'on-chain sync',
+      blockRange: { from: blockRange.start, to: blockRange.end },
+      verifiers: verifiers.length,
+      pages: pages.length,
+      pageMappings: pageMappings.length,
+      stateTransitions: stateTransitions.length,
+      userRegistrations: userRegistrations.length,
+      forcedEvents,
+      finalizeExitEvents,
+    })
+
+    return this.processStateTransitions(stateTransitions)
+  }
+
+  private async processStateTransitions(
+    stateTransitions: Omit<StateTransitionRecord, 'id'>[]
+  ): Promise<StateTransition[]> {
+    if (stateTransitions.length === 0) {
+      return []
+    }
+
+    const pageGroups = await this.pageRepository.getByStateTransitions(
+      stateTransitions.map((x) => x.stateTransitionHash)
+    )
+    const stateTransitionsWithPages = pageGroups.map((pages, i) => {
+      const stateTransition = stateTransitions[i]
+      if (stateTransition === undefined) {
+        throw new Error('Programmer error: state transition count mismatch')
+      }
+      return { ...stateTransition, pages }
+    })
+    if (pageGroups.length !== stateTransitions.length) {
+      throw new Error('Missing pages for state transitions in database')
+    }
+
+    const { oldHash, id } = await this.stateUpdater.readLastUpdate()
+    await this.stateUpdater.ensureRollupState(oldHash)
+
+    const result: StateTransition[] = []
+    for (const [i, stateTransition] of stateTransitionsWithPages.entries()) {
+      const onChainData = decodeOnChainData(stateTransition.pages)
+      result.push({
+        stateTransitionRecord: {
+          id: id + i + 1,
+          blockNumber: stateTransition.blockNumber,
+          stateTransitionHash: stateTransition.stateTransitionHash,
+        },
+        onChainData,
+      })
+    }
+
+    return result
+  }
+
+  async discardAfter(blockNumber: BlockNumber) {
+    await this.verifierCollector.discardAfter(blockNumber)
+    await this.pageMappingCollector.discardAfter(blockNumber)
+    await this.pageCollector.discardAfter(blockNumber)
+    await this.stateTransitionCollector.discardAfter(blockNumber)
+    await this.stateUpdater.discardAfter(blockNumber)
+    await this.userRegistrationCollector.discardAfter(blockNumber)
+  }
+}

--- a/packages/backend/src/core/StateUpdater.ts
+++ b/packages/backend/src/core/StateUpdater.ts
@@ -1,9 +1,8 @@
-import { decodeOnChainData, ForcedAction } from '@explorer/encoding'
+import { ForcedAction, OnChainData } from '@explorer/encoding'
 import { RollupState } from '@explorer/state'
 import { Hash256, PedersenHash, Timestamp } from '@explorer/types'
 
 import { ForcedTransactionsRepository } from '../peripherals/database/ForcedTransactionsRepository'
-import { PageRepository } from '../peripherals/database/PageRepository'
 import { PositionRecord } from '../peripherals/database/PositionRepository'
 import { RollupStateRepository } from '../peripherals/database/RollupStateRepository'
 import { StateTransitionRecord } from '../peripherals/database/StateTransitionRepository'
@@ -20,15 +19,13 @@ export const ROLLUP_STATE_EMPTY_HASH = PedersenHash(
   '52ddcbdd431a044cf838a71d194248640210b316d7b1a568997ecad9dec9626'
 )
 
-interface StateTransition {
-  blockNumber: number
-  stateTransitionHash: Hash256
-  pages: string[]
+export interface StateTransition {
+  stateTransitionRecord: StateTransitionRecord
+  onChainData: OnChainData
 }
 
 export class StateUpdater {
   constructor(
-    private readonly pageRepository: PageRepository,
     private readonly stateUpdateRepository: StateUpdateRepository,
     private readonly rollupStateRepository: RollupStateRepository,
     private readonly ethereumClient: EthereumClient,
@@ -37,54 +34,28 @@ export class StateUpdater {
     private rollupState?: RollupState
   ) {}
 
-  async save(stateTransitions: Omit<StateTransitionRecord, 'id'>[]) {
-    if (stateTransitions.length === 0) {
-      return
-    }
-
-    const pageGroups = await this.pageRepository.getByStateTransitions(
-      stateTransitions.map((x) => x.stateTransitionHash)
-    )
-    const stateTransitionsWithPages = pageGroups.map((pages, i) => {
-      const stateTransition = stateTransitions[i]
-      if (stateTransition === undefined) {
-        throw new Error('Programmer error: state transition count mismatch')
-      }
-      return { ...stateTransition, pages }
-    })
-    if (pageGroups.length !== stateTransitions.length) {
-      throw new Error('Missing pages for state transitions in database')
-    }
-
-    const { oldHash, id } = await this.readLastUpdate()
-    await this.ensureRollupState(oldHash)
-
-    for (const [i, stateTransition] of stateTransitionsWithPages.entries()) {
-      await this.processStateTransition(stateTransition, id + i + 1)
-    }
-  }
-
-  async processStateTransition(
-    { pages, stateTransitionHash, blockNumber }: StateTransition,
-    id: number
-  ) {
+  async processStateTransition({
+    stateTransitionRecord,
+    onChainData,
+  }: StateTransition) {
     if (!this.rollupState) {
       return
     }
+    const { id, blockNumber, stateTransitionHash } = stateTransitionRecord
     const block = await this.ethereumClient.getBlock(blockNumber)
     const timestamp = Timestamp.fromSeconds(block.timestamp)
 
-    const decoded = decodeOnChainData(pages)
-
-    const [rollupState, newPositions] = await this.rollupState.update(decoded)
+    const [rollupState, newPositions] = await this.rollupState.update(
+      onChainData
+    )
     this.rollupState = rollupState
 
     const rootHash = await rollupState.positions.hash()
-    if (rootHash !== decoded.newState.positionRoot) {
+    if (rootHash !== onChainData.newState.positionRoot) {
       throw new Error('State transition calculated incorrectly')
     }
     const transactionHashes = await this.extractTransactionHashes(
-      decoded.forcedActions
+      onChainData.forcedActions
     )
     await Promise.all([
       this.stateUpdateRepository.add({
@@ -103,7 +74,7 @@ export class StateUpdater {
             collateralBalance: value.collateralBalance,
           })
         ),
-        prices: decoded.newState.oraclePrices,
+        prices: onChainData.newState.oraclePrices,
         transactionHashes,
       }),
     ])
@@ -134,7 +105,7 @@ export class StateUpdater {
     await this.stateUpdateRepository.deleteAfter(blockNumber)
   }
 
-  private async readLastUpdate() {
+  async readLastUpdate() {
     const lastUpdate = await this.stateUpdateRepository.findLast()
     if (lastUpdate) {
       return { oldHash: lastUpdate.rootHash, id: lastUpdate.id }


### PR DESCRIPTION
Resolves L2B-462

Refactoring data collection so that StateUpdater doesn't have to deal with "pages". Pages are transformed into StateTransition objects by data collector.