### PR TITLE
Add ForcedWithdrawRepository

### DIFF
--- a/packages/backend/src/peripherals/database/ForcedWithdrawRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ForcedWithdrawRepository.test.ts
@@ -1,0 +1,28 @@
+import { Hash256, StarkKey, Timestamp } from '@explorer/types'
+import { expect } from 'earljs'
+
+import { setupDatabaseTestSuite } from '../../test/database'
+import { Logger } from '../../tools/Logger'
+import {
+  ForcedWithdrawRepository,
+  ForcedWithdrawTransactionRecord,
+} from './ForcedWithdrawRepository'
+
+describe(ForcedWithdrawRepository.name, () => {
+  const { database } = setupDatabaseTestSuite()
+  const repository = new ForcedWithdrawRepository(database, Logger.SILENT)
+
+  afterEach(() => repository.deleteAll())
+
+  it('adds single record and queries it', async () => {
+    const record: ForcedWithdrawTransactionRecord = {
+      hash: Hash256.fake(),
+      starkKey: StarkKey.fake(),
+      amount: 1n,
+      positionId: 2n,
+    }
+    await repository.addSent({ ...record, sentAt: Timestamp.now() })
+    const result = await repository.findByTransactionHash(record.hash)
+    expect(result).toEqual(record)
+  })
+})

--- a/packages/backend/src/peripherals/database/ForcedWithdrawRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ForcedWithdrawRepository.test.ts
@@ -14,15 +14,150 @@ describe(ForcedWithdrawRepository.name, () => {
 
   afterEach(() => repository.deleteAll())
 
-  it('adds single record and queries it', async () => {
+  describe('status history', () => {
     const record: ForcedWithdrawTransactionRecord = {
       hash: Hash256.fake(),
       starkKey: StarkKey.fake(),
       amount: 1n,
       positionId: 2n,
     }
-    await repository.addSent({ ...record, sentAt: Timestamp.now() })
-    const result = await repository.findByTransactionHash(record.hash)
-    expect(result).toEqual(record)
+
+    const sentTimestamp = Timestamp.now()
+    const forgottenTimestamp = Timestamp(Number(sentTimestamp) + 1000)
+    const revertedTimestamp = Timestamp(Number(forgottenTimestamp) + 1000)
+    const minedTimestamp = Timestamp(Number(revertedTimestamp) + 1000)
+    const includedTimestamp = Timestamp(Number(minedTimestamp) + 1000)
+
+    it('adds single record and queries it', async () => {
+      await repository.addSent({ ...record, timestamp: sentTimestamp })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [{ status: 'sent', timestamp: sentTimestamp }],
+      })
+    })
+
+    it('returns undefined for unknown hash', async () => {
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual(undefined)
+    })
+
+    it('can track a regular flow', async () => {
+      await repository.addSent({ ...record, timestamp: sentTimestamp })
+      await repository.addMined({
+        ...record,
+        timestamp: minedTimestamp,
+        blockNumber: 123,
+      })
+      await repository.addIncluded({
+        hash: record.hash,
+        timestamp: includedTimestamp,
+        blockNumber: 456,
+        stateUpdateId: 100,
+      })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: sentTimestamp },
+          { status: 'mined', timestamp: minedTimestamp, blockNumber: 123 },
+          {
+            status: 'included',
+            timestamp: includedTimestamp,
+            blockNumber: 456,
+            stateUpdateId: 100,
+          },
+        ],
+      })
+    })
+
+    it('can track a forgotten flow', async () => {
+      await repository.addSent({ ...record, timestamp: sentTimestamp })
+      await repository.addForgotten({
+        hash: record.hash,
+        timestamp: forgottenTimestamp,
+      })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: sentTimestamp },
+          { status: 'forgotten', timestamp: forgottenTimestamp },
+        ],
+      })
+    })
+
+    it('can track a reverted flow', async () => {
+      await repository.addSent({ ...record, timestamp: sentTimestamp })
+      await repository.addReverted({
+        hash: record.hash,
+        timestamp: revertedTimestamp,
+        blockNumber: 123,
+      })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: sentTimestamp },
+          {
+            status: 'reverted',
+            timestamp: revertedTimestamp,
+            blockNumber: 123,
+          },
+        ],
+      })
+    })
+
+    it('orders events by timestamp', async () => {
+      await repository.addIncluded({
+        hash: record.hash,
+        timestamp: includedTimestamp,
+        blockNumber: 789,
+        stateUpdateId: 100,
+      })
+      await repository.addReverted({
+        hash: record.hash,
+        timestamp: revertedTimestamp,
+        blockNumber: 123,
+      })
+      await repository.addMined({
+        ...record,
+        hash: record.hash,
+        timestamp: minedTimestamp,
+        blockNumber: 456,
+      })
+      await repository.addSent({ ...record, timestamp: sentTimestamp })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: sentTimestamp },
+          {
+            status: 'reverted',
+            timestamp: revertedTimestamp,
+            blockNumber: 123,
+          },
+          { status: 'mined', timestamp: minedTimestamp, blockNumber: 456 },
+          {
+            status: 'included',
+            timestamp: includedTimestamp,
+            blockNumber: 789,
+            stateUpdateId: 100,
+          },
+        ],
+      })
+    })
+
+    it('prevents adding the same status twice', async () => {
+      await repository.addSent({ ...record, timestamp: sentTimestamp })
+      await expect(
+        repository.addSent({ ...record, timestamp: sentTimestamp })
+      ).toBeRejected()
+    })
   })
 })

--- a/packages/backend/src/peripherals/database/ForcedWithdrawRepository.ts
+++ b/packages/backend/src/peripherals/database/ForcedWithdrawRepository.ts
@@ -1,5 +1,8 @@
 import { Hash256, StarkKey, Timestamp } from '@explorer/types'
-import { ForcedWithdrawTransactionRow } from 'knex/types/tables'
+import {
+  ForcedWithdrawStatusRow,
+  ForcedWithdrawTransactionRow,
+} from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
 import { BaseRepository } from './shared/BaseRepository'
@@ -12,6 +15,47 @@ export interface ForcedWithdrawTransactionRecord {
   positionId: bigint
 }
 
+export interface ForcedWithdrawTransactionWithHistory
+  extends ForcedWithdrawTransactionRecord {
+  history: ForcedWithdrawStatus[]
+}
+
+export type ForcedWithdrawStatus =
+  | SentStatus
+  | MinedStatus
+  | RevertedStatus
+  | ForgottenStatus
+  | IncludedStatus
+
+export interface SentStatus {
+  status: 'sent'
+  timestamp: Timestamp
+}
+
+export interface MinedStatus {
+  status: 'mined'
+  timestamp: Timestamp
+  blockNumber: number
+}
+
+export interface RevertedStatus {
+  status: 'reverted'
+  timestamp: Timestamp
+  blockNumber: number
+}
+
+export interface ForgottenStatus {
+  status: 'forgotten'
+  timestamp: Timestamp
+}
+
+export interface IncludedStatus {
+  status: 'included'
+  timestamp: Timestamp
+  blockNumber: number
+  stateUpdateId: number
+}
+
 export class ForcedWithdrawRepository extends BaseRepository {
   constructor(database: Database, logger: Logger) {
     super(database, logger)
@@ -19,16 +63,17 @@ export class ForcedWithdrawRepository extends BaseRepository {
     /* eslint-disable @typescript-eslint/unbound-method */
 
     this.addSent = this.wrapAdd(this.addSent)
-    // this.addMined = this.wrapXXX(this.addMined)
-    // this.addReverted = this.wrapXXX(this.addReverted)
-    // this.addForgotten = this.wrapXXX(this.addForgotten)
-    // this.addFinalized = this.wrapXXX(this.addFinalized)
+    this.addMined = this.wrapAdd(this.addMined)
+    this.addReverted = this.wrapAdd(this.addReverted)
+    this.addForgotten = this.wrapAdd(this.addForgotten)
+    this.addIncluded = this.wrapAdd(this.addIncluded)
     this.findByTransactionHash = this.wrapFind(this.findByTransactionHash)
-    // this.getByPositionId = this.wrapXXX(this.getByPositionId)
-    // this.getByStarkKey = this.wrapXXX(this.getByStarkKey)
-    // this.getByStateUpdateId = this.wrapXXX(this.getByStateUpdateId)
-    // this.getNotMined = this.wrapXXX(this.getNotMined)
-    // this.getMinedNotFinalized = this.wrapXXX(this.getMinedNotFinalized)
+    // this.getLatest = this.wrapGet(this.getLatest)
+    // this.getByPositionId = this.wrapGet(this.getByPositionId)
+    // this.getByStarkKey = this.wrapGet(this.getByStarkKey)
+    // this.getByStateUpdateId = this.wrapGet(this.getByStateUpdateId)
+    // this.getPending = this.wrapGet(this.getPending)
+    // this.getMinedNotFinalized = this.wrapGet(this.getMinedNotFinalized)
     this.deleteAll = this.wrapDelete(this.deleteAll)
     this.deleteAfter = this.wrapDelete(this.deleteAfter)
 
@@ -36,7 +81,7 @@ export class ForcedWithdrawRepository extends BaseRepository {
   }
 
   async addSent(
-    record: ForcedWithdrawTransactionRecord & { sentAt: Timestamp }
+    record: ForcedWithdrawTransactionRecord & { timestamp: Timestamp }
   ): Promise<Hash256> {
     const knex = await this.knex()
     await knex.transaction(async (trx) => {
@@ -44,20 +89,85 @@ export class ForcedWithdrawRepository extends BaseRepository {
         .insert(toRow(record))
         .onConflict('hash')
         .ignore()
-
       await trx('forced_withdraw_statuses').insert({
         hash: record.hash.toString(),
         status: 'sent',
-        timestamp: BigInt(record.sentAt.toString()),
+        timestamp: BigInt(record.timestamp.toString()),
       })
     })
-
     return record.hash
+  }
+
+  async addMined(
+    record: ForcedWithdrawTransactionRecord & {
+      timestamp: Timestamp
+      blockNumber: number
+    }
+  ): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex.transaction(async (trx) => {
+      await trx('forced_withdraw_transactions')
+        .insert(toRow(record))
+        .onConflict('hash')
+        .ignore()
+      await trx('forced_withdraw_statuses').insert({
+        hash: record.hash.toString(),
+        status: 'mined',
+        timestamp: BigInt(record.timestamp.toString()),
+        block_number: record.blockNumber,
+      })
+    })
+    return record.hash
+  }
+
+  async addReverted(status: {
+    hash: Hash256
+    timestamp: Timestamp
+    blockNumber: number
+  }): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex('forced_withdraw_statuses').insert({
+      hash: status.hash.toString(),
+      status: 'reverted',
+      timestamp: BigInt(status.timestamp.toString()),
+      block_number: status.blockNumber,
+    })
+    return status.hash
+  }
+
+  async addForgotten(status: {
+    hash: Hash256
+    timestamp: Timestamp
+  }): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex('forced_withdraw_statuses').insert({
+      hash: status.hash.toString(),
+      status: 'forgotten',
+      timestamp: BigInt(status.timestamp.toString()),
+    })
+    return status.hash
+  }
+
+  async addIncluded(status: {
+    hash: Hash256
+    timestamp: Timestamp
+    blockNumber: number
+    stateUpdateId: number
+  }): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex('forced_withdraw_statuses').insert({
+      hash: status.hash.toString(),
+      status: 'included',
+      timestamp: BigInt(status.timestamp.toString()),
+      block_number: status.blockNumber,
+      state_update_id: status.stateUpdateId,
+    })
+    return status.hash
   }
 
   async findByTransactionHash(
     hash: Hash256
-  ): Promise<ForcedWithdrawTransactionRecord | undefined> {
+  ): Promise<ForcedWithdrawTransactionWithHistory | undefined> {
     const knex = await this.knex()
     const row = await knex('forced_withdraw_transactions')
       .where('hash', hash.toString())
@@ -65,7 +175,24 @@ export class ForcedWithdrawRepository extends BaseRepository {
     if (!row) {
       return undefined
     }
-    return toRecord(row)
+    const record = toRecord(row)
+    const [result] = await this.recordsWithHistories([record])
+    return result
+  }
+
+  private async recordsWithHistories(
+    records: ForcedWithdrawTransactionRecord[]
+  ): Promise<ForcedWithdrawTransactionWithHistory[]> {
+    const knex = await this.knex()
+    const rows = await knex('forced_withdraw_statuses')
+      .whereIn('hash', [records.map((x) => x.hash.toString())])
+      .orderBy('timestamp', 'asc')
+    return records.map((record) => ({
+      ...record,
+      history: rows
+        .filter((x) => x.hash === record.hash.toString())
+        .map(toHistoryRow),
+    }))
   }
 
   async deleteAll() {
@@ -102,5 +229,51 @@ function toRow(
     stark_key: row.starkKey.toString(),
     amount: row.amount,
     position_id: row.positionId,
+  }
+}
+
+function toHistoryRow(row: ForcedWithdrawStatusRow): ForcedWithdrawStatus {
+  switch (row.status) {
+    case 'sent':
+      return {
+        status: 'sent',
+        timestamp: Timestamp(row.timestamp),
+      }
+    case 'mined':
+      if (row.block_number == null) {
+        throw new Error('Corrupt database: block_number is null')
+      }
+      return {
+        status: 'mined',
+        timestamp: Timestamp(row.timestamp),
+        blockNumber: row.block_number,
+      }
+    case 'reverted':
+      if (row.block_number == null) {
+        throw new Error('Corrupt database: block_number is null')
+      }
+      return {
+        status: 'reverted',
+        timestamp: Timestamp(row.timestamp),
+        blockNumber: row.block_number,
+      }
+    case 'forgotten':
+      return {
+        status: 'forgotten',
+        timestamp: Timestamp(row.timestamp),
+      }
+    case 'included':
+      if (row.block_number == null) {
+        throw new Error('Corrupt database: block_number is null')
+      }
+      if (row.state_update_id == null) {
+        throw new Error('Corrupt database: state_update_id is null')
+      }
+      return {
+        status: 'included',
+        timestamp: Timestamp(row.timestamp),
+        blockNumber: row.block_number,
+        stateUpdateId: row.state_update_id,
+      }
   }
 }

--- a/packages/backend/src/peripherals/database/ForcedWithdrawRepository.ts
+++ b/packages/backend/src/peripherals/database/ForcedWithdrawRepository.ts
@@ -311,13 +311,13 @@ function toRecord(
 }
 
 function toRow(
-  row: ForcedWithdrawTransactionRecord
+  record: ForcedWithdrawTransactionRecord
 ): ForcedWithdrawTransactionRow {
   return {
-    hash: row.hash.toString(),
-    stark_key: row.starkKey.toString(),
-    amount: row.amount,
-    position_id: row.positionId,
+    hash: record.hash.toString(),
+    stark_key: record.starkKey.toString(),
+    amount: record.amount,
+    position_id: record.positionId,
   }
 }
 

--- a/packages/backend/src/peripherals/database/ForcedWithdrawRepository.ts
+++ b/packages/backend/src/peripherals/database/ForcedWithdrawRepository.ts
@@ -1,0 +1,106 @@
+import { Hash256, StarkKey, Timestamp } from '@explorer/types'
+import { ForcedWithdrawTransactionRow } from 'knex/types/tables'
+
+import { Logger } from '../../tools/Logger'
+import { BaseRepository } from './shared/BaseRepository'
+import { Database } from './shared/Database'
+
+export interface ForcedWithdrawTransactionRecord {
+  hash: Hash256
+  starkKey: StarkKey
+  amount: bigint
+  positionId: bigint
+}
+
+export class ForcedWithdrawRepository extends BaseRepository {
+  constructor(database: Database, logger: Logger) {
+    super(database, logger)
+
+    /* eslint-disable @typescript-eslint/unbound-method */
+
+    this.addSent = this.wrapAdd(this.addSent)
+    // this.addMined = this.wrapXXX(this.addMined)
+    // this.addReverted = this.wrapXXX(this.addReverted)
+    // this.addForgotten = this.wrapXXX(this.addForgotten)
+    // this.addFinalized = this.wrapXXX(this.addFinalized)
+    this.findByTransactionHash = this.wrapFind(this.findByTransactionHash)
+    // this.getByPositionId = this.wrapXXX(this.getByPositionId)
+    // this.getByStarkKey = this.wrapXXX(this.getByStarkKey)
+    // this.getByStateUpdateId = this.wrapXXX(this.getByStateUpdateId)
+    // this.getNotMined = this.wrapXXX(this.getNotMined)
+    // this.getMinedNotFinalized = this.wrapXXX(this.getMinedNotFinalized)
+    this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.deleteAfter = this.wrapDelete(this.deleteAfter)
+
+    /* eslint-enable @typescript-eslint/unbound-method */
+  }
+
+  async addSent(
+    record: ForcedWithdrawTransactionRecord & { sentAt: Timestamp }
+  ): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex.transaction(async (trx) => {
+      await trx('forced_withdraw_transactions')
+        .insert(toRow(record))
+        .onConflict('hash')
+        .ignore()
+
+      await trx('forced_withdraw_statuses').insert({
+        hash: record.hash.toString(),
+        status: 'sent',
+        timestamp: BigInt(record.sentAt.toString()),
+      })
+    })
+
+    return record.hash
+  }
+
+  async findByTransactionHash(
+    hash: Hash256
+  ): Promise<ForcedWithdrawTransactionRecord | undefined> {
+    const knex = await this.knex()
+    const row = await knex('forced_withdraw_transactions')
+      .where('hash', hash.toString())
+      .first()
+    if (!row) {
+      return undefined
+    }
+    return toRecord(row)
+  }
+
+  async deleteAll() {
+    const knex = await this.knex()
+    const countA = await knex('forced_withdraw_transactions').delete()
+    const countB = await knex('forced_withdraw_statuses').delete()
+    return countA + countB
+  }
+
+  async deleteAfter(blockNumber: number) {
+    const knex = await this.knex()
+    return await knex('forced_withdraw_statuses')
+      .where('block_number', '>', blockNumber)
+      .delete()
+  }
+}
+
+function toRecord(
+  row: ForcedWithdrawTransactionRow
+): ForcedWithdrawTransactionRecord {
+  return {
+    hash: Hash256(row.hash),
+    starkKey: StarkKey(row.stark_key),
+    amount: row.amount,
+    positionId: row.position_id,
+  }
+}
+
+function toRow(
+  row: ForcedWithdrawTransactionRecord
+): ForcedWithdrawTransactionRow {
+  return {
+    hash: row.hash.toString(),
+    stark_key: row.starkKey.toString(),
+    amount: row.amount,
+    position_id: row.positionId,
+  }
+}

--- a/packages/backend/src/peripherals/database/migrations/024_transactions_refactor.ts
+++ b/packages/backend/src/peripherals/database/migrations/024_transactions_refactor.ts
@@ -1,0 +1,100 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.createTable('forced_withdraw_transactions', (table) => {
+    table.string('hash').primary()
+    table.string('stark_key').notNullable()
+    table.bigInteger('amount').notNullable()
+    table.bigInteger('position_id').notNullable()
+
+    table.index('stark_key')
+    table.index('position_id')
+  })
+
+  await knex.schema.createTable('forced_withdraw_statuses', (table) => {
+    table.string('hash').notNullable()
+    table.string('status').notNullable()
+
+    table.bigInteger('timestamp').notNullable()
+    table.integer('block_number')
+    table.integer('state_update_id')
+
+    table.primary(['hash', 'status'])
+    table.index('state_update_id')
+  })
+
+  await knex.schema.createTable('forced_trade_transactions', (table) => {
+    table.string('hash').primary()
+    table.string('stark_key_a').notNullable()
+    table.string('stark_key_b').notNullable()
+    table.bigInteger('position_id_a').notNullable()
+    table.bigInteger('position_id_b').notNullable()
+    table.bigInteger('collateral_amount').notNullable()
+    table.bigInteger('synthetic_amount').notNullable()
+    table.boolean('is_a_buying_synthetic').notNullable()
+    table.string('synthetic_asset_id').notNullable()
+    table.bigInteger('nonce').notNullable()
+
+    table.index('stark_key_a')
+    table.index('stark_key_b')
+    table.index('position_id_a')
+    table.index('position_id_b')
+    table.index('synthetic_asset_id')
+  })
+
+  await knex.schema.createTable('forced_trade_statuses', (table) => {
+    table.string('hash').notNullable()
+    table.string('status').notNullable()
+
+    table.bigInteger('timestamp').notNullable()
+    table.integer('block_number')
+    table.integer('offer_id')
+    table.integer('state_update_id')
+
+    table.primary(['hash', 'status'])
+    table.index('offer_id')
+    table.index('state_update_id')
+  })
+
+  await knex.schema.createTable('withdraw_transactions', (table) => {
+    table.string('hash').primary()
+    table.string('stark_key').notNullable()
+    table.string('asset_type').notNullable()
+  })
+
+  await knex.schema.createTable('withdraw_statuses', (table) => {
+    table.string('hash').primary()
+    table.string('status').notNullable()
+
+    table.bigInteger('timestamp').notNullable()
+    table.integer('block_number')
+    table.bigInteger('quantized_amount') // TODO: rename?
+    table.bigInteger('non_quantized_amount') // TODO: rename?
+    table.string('recipient_address')
+
+    table.primary(['hash', 'status'])
+    table.index('recipient_address')
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.dropTable('forced_withdraw_transactions')
+  await knex.schema.dropTable('forced_withdraw_statuses')
+  await knex.schema.dropTable('forced_trade_transactions')
+  await knex.schema.dropTable('forced_trade_statuses')
+  await knex.schema.dropTable('withdraw_transactions')
+  await knex.schema.dropTable('withdraw_statuses')
+}

--- a/packages/backend/src/peripherals/database/shared/Database.test.ts
+++ b/packages/backend/src/peripherals/database/shared/Database.test.ts
@@ -1,4 +1,6 @@
 import { expect } from 'earljs'
+import { readdirSync } from 'fs'
+import path from 'path'
 
 import { getTestDatabase } from '../../../test/database'
 import { Database } from './Database'
@@ -22,5 +24,14 @@ describe(Database.name, () => {
     expect(tables).toEqual(['knex_migrations', 'knex_migrations_lock'])
 
     await database.closeConnection()
+  })
+
+  it('migrations have consecutive numbering', () => {
+    const migrationsDirectory = path.resolve(__dirname, '../migrations')
+    const fileNames = readdirSync(migrationsDirectory).sort()
+    for (const [i, fileName] of fileNames.entries()) {
+      const number = parseInt(fileName.slice(0, 3))
+      expect(number).toEqual(i + 1)
+    }
   })
 })

--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -2,8 +2,6 @@ import { json } from '@explorer/types'
 
 import { Nullable } from '../../../utils/Nullable'
 
-export {}
-
 declare module 'knex/types/tables' {
   interface KeyValueRow {
     key: string
@@ -155,6 +153,59 @@ declare module 'knex/types/tables' {
     cancelled_at: Nullable<bigint>
   }
 
+  interface ForcedWithdrawTransactionRow {
+    hash: string
+    stark_key: string
+    amount: bigint
+    position_id: bigint
+  }
+
+  interface ForcedWithdrawStatusRow {
+    hash: string
+    status: 'sent' | 'forgotten' | 'reverted' | 'mined' | 'included'
+    timestamp: bigint
+    block_number: Nullable<number>
+    state_update_id: Nullable<number>
+  }
+
+  interface ForcedTradeTransactionRow {
+    hash: string
+    stark_key_a: string
+    stark_key_b: string
+    position_id_a: bigint
+    position_id_b: bigint
+    collateral_amount: bigint
+    synthetic_amount: bigint
+    is_a_buying_synthetic: boolean
+    synthetic_asset_id: string
+    nonce: bigint
+  }
+
+  interface ForcedTradeStatusRow {
+    hash: string
+    status: string
+    timestamp: bigint
+    block_number: Nullable<number>
+    offer_id: Nullable<number>
+    state_update_id: Nullable<number>
+  }
+
+  interface WithdrawTransactionRow {
+    hash: string
+    stark_key: string
+    asset_type: string
+  }
+
+  interface WithdrawStatusRow {
+    hash: string
+    status: string
+    timestamp: bigint
+    block_number: Nullable<number>
+    quantized_amount: Nullable<bigint>
+    non_quantized_amount: Nullable<bigint>
+    recipient_address: Nullable<string>
+  }
+
   interface Tables {
     key_values: KeyValueRow
     verifier_events: VerifierEventRow
@@ -175,6 +226,12 @@ declare module 'knex/types/tables' {
     user_registration_events: UserRegistrationEventRow
     forced_trade_offers: ForcedTradeOfferRow
     vaults: VaultRow
+    forced_withdraw_transactions: ForcedWithdrawTransactionRow
+    forced_withdraw_statuses: ForcedWithdrawStatusRow
+    forced_trade_transactions: ForcedTradeTransactionRow
+    forced_trade_statuses: ForcedTradeStatusRow
+    withdraw_transactions: WithdrawTransactionRow
+    withdraw_statuses: WithdrawStatusRow
   }
 }
 

--- a/packages/backend/src/utils/compareByHistory.test.ts
+++ b/packages/backend/src/utils/compareByHistory.test.ts
@@ -1,0 +1,73 @@
+import { Timestamp } from '@explorer/types'
+import { expect } from 'earljs'
+
+import { compareByHistory } from './compareByHistory'
+
+describe(compareByHistory.name, () => {
+  it('returns 0 if both records have no history', () => {
+    const record1 = { history: [] }
+    const record2 = { history: [] }
+    expect(compareByHistory(record1, record2)).toEqual(0)
+    expect(compareByHistory(record2, record1)).toEqual(0)
+  })
+
+  it('similar but longer history is greater', () => {
+    const record1 = {
+      history: [{ timestamp: Timestamp(100) }, { timestamp: Timestamp(200) }],
+    }
+    const record2 = {
+      history: [{ timestamp: Timestamp(200) }],
+    }
+    expect(compareByHistory(record1, record2)).toEqual(-1)
+    expect(compareByHistory(record2, record1)).toEqual(1)
+  })
+
+  it('single entry', () => {
+    const record1 = {
+      history: [{ timestamp: Timestamp(100) }],
+    }
+    const record2 = {
+      history: [{ timestamp: Timestamp(200) }],
+    }
+    expect(compareByHistory(record1, record2)).toEqual(-1)
+    expect(compareByHistory(record2, record1)).toEqual(1)
+  })
+
+  it('multiple entries - equal', () => {
+    const record1 = {
+      history: [
+        { timestamp: Timestamp(100) },
+        { timestamp: Timestamp(200) },
+        { timestamp: Timestamp(300) },
+      ],
+    }
+    const record2 = {
+      history: [
+        { timestamp: Timestamp(100) },
+        { timestamp: Timestamp(200) },
+        { timestamp: Timestamp(300) },
+      ],
+    }
+    expect(compareByHistory(record1, record2)).toEqual(0)
+    expect(compareByHistory(record2, record1)).toEqual(0)
+  })
+
+  it('multiple entries - unequal', () => {
+    const record1 = {
+      history: [
+        { timestamp: Timestamp(100) },
+        { timestamp: Timestamp(300) },
+        { timestamp: Timestamp(400) },
+      ],
+    }
+    const record2 = {
+      history: [
+        { timestamp: Timestamp(200) },
+        { timestamp: Timestamp(300) },
+        { timestamp: Timestamp(400) },
+      ],
+    }
+    expect(compareByHistory(record1, record2)).toEqual(-1)
+    expect(compareByHistory(record2, record1)).toEqual(1)
+  })
+})

--- a/packages/backend/src/utils/compareByHistory.ts
+++ b/packages/backend/src/utils/compareByHistory.ts
@@ -1,0 +1,16 @@
+import { Timestamp } from '@explorer/types'
+
+export function compareByHistory<
+  T extends { history: { timestamp: Timestamp }[] }
+>(a: T, b: T) {
+  const maxComparisons = Math.max(a.history.length, b.history.length)
+  for (let i = 0; i < maxComparisons; i++) {
+    const aTimestamp = a.history.at(-1 - i)?.timestamp ?? Infinity
+    const bTimestamp = b.history.at(-1 - i)?.timestamp ?? Infinity
+    const diff = Number(aTimestamp) - Number(bTimestamp)
+    if (diff !== 0) {
+      return diff < 0 ? -1 : 1
+    }
+  }
+  return 0
+}

--- a/packages/types/src/Timestamp.ts
+++ b/packages/types/src/Timestamp.ts
@@ -10,6 +10,10 @@ export function Timestamp(milliseconds: number | bigint) {
   return numberMilliseconds as unknown as Timestamp
 }
 
+Timestamp.now = function now() {
+  return Timestamp(Date.now())
+}
+
 Timestamp.fromSeconds = function fromSeconds(seconds: number | bigint) {
   return Timestamp(Number(seconds) * 1000)
 }


### PR DESCRIPTION
Resolves L2B-622, L2B-638

This PR adds the following:
- new database tables. There are two tables for transaction type: one with data, the other with tx status. This is different than previously discussed where tx status was shared between all transactions. The reason is that withdraw txs have a different looking mined status, because once they are mined we know how much money was withdrawn.
- types for the new tables
- a test for migration numbers backported from the L2BEAT repo
- a small addition to the Timestamp type
- a repository for handling forced withdraw transactions

We'll soon see if having different tables for statuses per transaction type makes sense, because in a future PR I'll need to implement querying from both forced withdraw and forced trade txs to show this view https://dydx.l2beat.com/forced.

The main intent is of course for the changes to replace https://github.com/l2beat/starkex-explorer/blob/830f7c7f14b26a266c2992e64454eea3065dcc94/packages/backend/src/peripherals/database/ForcedTransactionRepository.ts as this is a nightmare to maintain.