### PR TITLE
Add ForcedTradeRepository 

### DIFF
--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -183,7 +183,7 @@ declare module 'knex/types/tables' {
 
   interface ForcedTradeStatusRow {
     hash: string
-    status: string
+    status: 'sent' | 'forgotten' | 'reverted' | 'mined' | 'included'
     timestamp: bigint
     block_number: Nullable<number>
     offer_id: Nullable<number>

--- a/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.test.ts
+++ b/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.test.ts
@@ -195,6 +195,31 @@ describe(ForcedTradeRepository.name, () => {
     })
   })
 
+  describe(ForcedTradeRepository.prototype.findByOfferId.name, () => {
+    it('returns undefined if there is no such offer', async () => {
+      const record1 = fakeRecord(1)
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 123,
+      })
+      expect(await repository.findByOfferId(456)).toEqual(undefined)
+    })
+
+    it('returns the record with the offer', async () => {
+      const record1 = fakeRecord(1)
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 123,
+      })
+      expect(await repository.findByOfferId(123)).toEqual({
+        ...record1,
+        history: [{ status: 'sent', timestamp: Timestamp(1001), offerId: 123 }],
+      })
+    })
+  })
+
   describe(ForcedTradeRepository.prototype.getMinedNotIncluded.name, () => {
     it('returns empty array if there are no mined transactions', async () => {
       const result = await repository.getMinedNotIncluded()

--- a/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.test.ts
+++ b/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.test.ts
@@ -35,12 +35,16 @@ describe(ForcedTradeRepository.name, () => {
     const record = fakeRecord(1)
 
     it('adds single record and queries it', async () => {
-      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
 
       const result = await repository.findByTransactionHash(record.hash)
       expect(result).toEqual({
         ...record,
-        history: [{ status: 'sent', timestamp: Timestamp(1001) }],
+        history: [{ status: 'sent', timestamp: Timestamp(1001), offerId: 1 }],
       })
     })
 
@@ -50,7 +54,11 @@ describe(ForcedTradeRepository.name, () => {
     })
 
     it('can track a regular flow', async () => {
-      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
       await repository.addMined({
         ...record,
         timestamp: Timestamp(1002),
@@ -67,7 +75,7 @@ describe(ForcedTradeRepository.name, () => {
       expect(result).toEqual({
         ...record,
         history: [
-          { status: 'sent', timestamp: Timestamp(1001) },
+          { status: 'sent', timestamp: Timestamp(1001), offerId: 1 },
           { status: 'mined', timestamp: Timestamp(1002), blockNumber: 123 },
           {
             status: 'included',
@@ -80,7 +88,11 @@ describe(ForcedTradeRepository.name, () => {
     })
 
     it('can track a forgotten flow', async () => {
-      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
       await repository.addForgotten({
         hash: record.hash,
         timestamp: Timestamp(1002),
@@ -90,14 +102,18 @@ describe(ForcedTradeRepository.name, () => {
       expect(result).toEqual({
         ...record,
         history: [
-          { status: 'sent', timestamp: Timestamp(1001) },
+          { status: 'sent', timestamp: Timestamp(1001), offerId: 1 },
           { status: 'forgotten', timestamp: Timestamp(1002) },
         ],
       })
     })
 
     it('can track a reverted flow', async () => {
-      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
       await repository.addReverted({
         hash: record.hash,
         timestamp: Timestamp(1002),
@@ -108,7 +124,7 @@ describe(ForcedTradeRepository.name, () => {
       expect(result).toEqual({
         ...record,
         history: [
-          { status: 'sent', timestamp: Timestamp(1001) },
+          { status: 'sent', timestamp: Timestamp(1001), offerId: 1 },
           {
             status: 'reverted',
             timestamp: Timestamp(1002),
@@ -136,13 +152,17 @@ describe(ForcedTradeRepository.name, () => {
         timestamp: Timestamp(1003),
         blockNumber: 456,
       })
-      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
 
       const result = await repository.findByTransactionHash(record.hash)
       expect(result).toEqual({
         ...record,
         history: [
-          { status: 'sent', timestamp: Timestamp(1001) },
+          { status: 'sent', timestamp: Timestamp(1001), offerId: 1 },
           {
             status: 'reverted',
             timestamp: Timestamp(1002),
@@ -160,9 +180,17 @@ describe(ForcedTradeRepository.name, () => {
     })
 
     it('prevents adding the same status twice', async () => {
-      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
       await expect(
-        repository.addSent({ ...record, timestamp: Timestamp(1001) })
+        repository.addSent({
+          ...record,
+          timestamp: Timestamp(1001),
+          offerId: 1,
+        })
       ).toBeRejected()
     })
   })
@@ -179,8 +207,16 @@ describe(ForcedTradeRepository.name, () => {
       const record3 = fakeRecord(3)
       const record4 = fakeRecord(4)
 
-      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
-      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
+      await repository.addSent({
+        ...record2,
+        timestamp: Timestamp(2001),
+        offerId: 2,
+      })
       await repository.addMined({
         ...record2,
         timestamp: Timestamp(2002),
@@ -208,7 +244,7 @@ describe(ForcedTradeRepository.name, () => {
         {
           ...record2,
           history: [
-            { status: 'sent', timestamp: Timestamp(2001) },
+            { status: 'sent', timestamp: Timestamp(2001), offerId: 2 },
             { status: 'mined', timestamp: Timestamp(2002), blockNumber: 123 },
           ],
         },
@@ -234,9 +270,21 @@ describe(ForcedTradeRepository.name, () => {
       const record3 = fakeRecord(3)
       const record4 = fakeRecord(4)
 
-      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
-      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
-      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
+      await repository.addSent({
+        ...record2,
+        timestamp: Timestamp(2001),
+        offerId: 2,
+      })
+      await repository.addSent({
+        ...record3,
+        timestamp: Timestamp(3001),
+        offerId: 3,
+      })
       await repository.addMined({
         ...record3,
         timestamp: Timestamp(3002),
@@ -264,9 +312,21 @@ describe(ForcedTradeRepository.name, () => {
       const record2 = fakeRecord(2, { positionIdA: 200n, positionIdB: 999n })
       const record3 = fakeRecord(3, { positionIdA: 999n, positionIdB: 200n })
 
-      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
-      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
-      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
+      await repository.addSent({
+        ...record2,
+        timestamp: Timestamp(2001),
+        offerId: 2,
+      })
+      await repository.addSent({
+        ...record3,
+        timestamp: Timestamp(3001),
+        offerId: 3,
+      })
       await repository.addMined({
         ...record3,
         timestamp: Timestamp(3002),
@@ -277,12 +337,12 @@ describe(ForcedTradeRepository.name, () => {
       expect(result).toEqual([
         {
           ...record2,
-          history: [{ status: 'sent', timestamp: Timestamp(2001) }],
+          history: [{ status: 'sent', timestamp: Timestamp(2001), offerId: 2 }],
         },
         {
           ...record3,
           history: [
-            { status: 'sent', timestamp: Timestamp(3001) },
+            { status: 'sent', timestamp: Timestamp(3001), offerId: 3 },
             { status: 'mined', timestamp: Timestamp(3002), blockNumber: 123 },
           ],
         },
@@ -310,9 +370,21 @@ describe(ForcedTradeRepository.name, () => {
         starkKeyB: StarkKey.fake('123'),
       })
 
-      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
-      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
-      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
+      await repository.addSent({
+        ...record2,
+        timestamp: Timestamp(2001),
+        offerId: 2,
+      })
+      await repository.addSent({
+        ...record3,
+        timestamp: Timestamp(3001),
+        offerId: 3,
+      })
       await repository.addMined({
         ...record3,
         timestamp: Timestamp(3002),
@@ -323,12 +395,12 @@ describe(ForcedTradeRepository.name, () => {
       expect(result).toEqual([
         {
           ...record2,
-          history: [{ status: 'sent', timestamp: Timestamp(2001) }],
+          history: [{ status: 'sent', timestamp: Timestamp(2001), offerId: 2 }],
         },
         {
           ...record3,
           history: [
-            { status: 'sent', timestamp: Timestamp(3001) },
+            { status: 'sent', timestamp: Timestamp(3001), offerId: 3 },
             { status: 'mined', timestamp: Timestamp(3002), blockNumber: 123 },
           ],
         },
@@ -348,7 +420,11 @@ describe(ForcedTradeRepository.name, () => {
       const record3 = fakeRecord(3)
       const record4 = fakeRecord(4)
 
-      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
       await repository.addMined({
         ...record1,
         timestamp: Timestamp(1002),
@@ -365,7 +441,11 @@ describe(ForcedTradeRepository.name, () => {
         blockNumber: 203,
         stateUpdateId: 1234,
       })
-      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addSent({
+        ...record3,
+        timestamp: Timestamp(3001),
+        offerId: 3,
+      })
       await repository.addMined({
         ...record3,
         timestamp: Timestamp(3002),
@@ -406,7 +486,7 @@ describe(ForcedTradeRepository.name, () => {
         {
           ...record3,
           history: [
-            { status: 'sent', timestamp: Timestamp(3001) },
+            { status: 'sent', timestamp: Timestamp(3001), offerId: 3 },
             { status: 'mined', timestamp: Timestamp(3002), blockNumber: 302 },
             {
               status: 'included',
@@ -426,7 +506,11 @@ describe(ForcedTradeRepository.name, () => {
       const record2 = fakeRecord(2)
       const record3 = fakeRecord(3)
 
-      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addSent({
+        ...record1,
+        timestamp: Timestamp(1001),
+        offerId: 1,
+      })
       await repository.addMined({
         ...record1,
         timestamp: Timestamp(1002),
@@ -447,7 +531,7 @@ describe(ForcedTradeRepository.name, () => {
 
       expect(await repository.findByTransactionHash(record1.hash)).toEqual({
         ...record1,
-        history: [{ status: 'sent', timestamp: Timestamp(1001) }],
+        history: [{ status: 'sent', timestamp: Timestamp(1001), offerId: 1 }],
       })
       expect(await repository.findByTransactionHash(record2.hash)).toEqual(
         undefined

--- a/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.test.ts
+++ b/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.test.ts
@@ -1,0 +1,463 @@
+import { AssetId, Hash256, StarkKey, Timestamp } from '@explorer/types'
+import { expect } from 'earljs'
+
+import { setupDatabaseTestSuite } from '../../../test/database'
+import { Logger } from '../../../tools/Logger'
+import {
+  ForcedTradeRepository,
+  ForcedTradeTransactionRecord,
+} from './ForcedTradeRepository'
+
+describe(ForcedTradeRepository.name, () => {
+  const { database } = setupDatabaseTestSuite()
+  const repository = new ForcedTradeRepository(database, Logger.SILENT)
+
+  afterEach(() => repository.deleteAll())
+
+  const fakeRecord = (
+    n: number,
+    overrides?: Partial<ForcedTradeTransactionRecord>
+  ): ForcedTradeTransactionRecord => ({
+    hash: Hash256.fake(n.toString().repeat(10)),
+    positionIdA: 1n,
+    positionIdB: 2n,
+    starkKeyA: StarkKey.fake(),
+    starkKeyB: StarkKey.fake(),
+    collateralAmount: 1234n,
+    syntheticAmount: 5678n,
+    syntheticAssetId: AssetId('ABC-4'),
+    isABuyingSynthetic: true,
+    nonce: 123n,
+    ...overrides,
+  })
+
+  describe('status history', () => {
+    const record = fakeRecord(1)
+
+    it('adds single record and queries it', async () => {
+      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [{ status: 'sent', timestamp: Timestamp(1001) }],
+      })
+    })
+
+    it('returns undefined for unknown hash', async () => {
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual(undefined)
+    })
+
+    it('can track a regular flow', async () => {
+      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addMined({
+        ...record,
+        timestamp: Timestamp(1002),
+        blockNumber: 123,
+      })
+      await repository.addIncluded({
+        hash: record.hash,
+        timestamp: Timestamp(1003),
+        blockNumber: 456,
+        stateUpdateId: 100,
+      })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: Timestamp(1001) },
+          { status: 'mined', timestamp: Timestamp(1002), blockNumber: 123 },
+          {
+            status: 'included',
+            timestamp: Timestamp(1003),
+            blockNumber: 456,
+            stateUpdateId: 100,
+          },
+        ],
+      })
+    })
+
+    it('can track a forgotten flow', async () => {
+      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addForgotten({
+        hash: record.hash,
+        timestamp: Timestamp(1002),
+      })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: Timestamp(1001) },
+          { status: 'forgotten', timestamp: Timestamp(1002) },
+        ],
+      })
+    })
+
+    it('can track a reverted flow', async () => {
+      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await repository.addReverted({
+        hash: record.hash,
+        timestamp: Timestamp(1002),
+        blockNumber: 123,
+      })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: Timestamp(1001) },
+          {
+            status: 'reverted',
+            timestamp: Timestamp(1002),
+            blockNumber: 123,
+          },
+        ],
+      })
+    })
+
+    it('orders events by timestamp', async () => {
+      await repository.addIncluded({
+        hash: record.hash,
+        timestamp: Timestamp(1004),
+        blockNumber: 789,
+        stateUpdateId: 100,
+      })
+      await repository.addReverted({
+        hash: record.hash,
+        timestamp: Timestamp(1002),
+        blockNumber: 123,
+      })
+      await repository.addMined({
+        ...record,
+        hash: record.hash,
+        timestamp: Timestamp(1003),
+        blockNumber: 456,
+      })
+      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+
+      const result = await repository.findByTransactionHash(record.hash)
+      expect(result).toEqual({
+        ...record,
+        history: [
+          { status: 'sent', timestamp: Timestamp(1001) },
+          {
+            status: 'reverted',
+            timestamp: Timestamp(1002),
+            blockNumber: 123,
+          },
+          { status: 'mined', timestamp: Timestamp(1003), blockNumber: 456 },
+          {
+            status: 'included',
+            timestamp: Timestamp(1004),
+            blockNumber: 789,
+            stateUpdateId: 100,
+          },
+        ],
+      })
+    })
+
+    it('prevents adding the same status twice', async () => {
+      await repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      await expect(
+        repository.addSent({ ...record, timestamp: Timestamp(1001) })
+      ).toBeRejected()
+    })
+  })
+
+  describe(ForcedTradeRepository.prototype.getMinedNotIncluded.name, () => {
+    it('returns empty array if there are no mined transactions', async () => {
+      const result = await repository.getMinedNotIncluded()
+      expect(result).toEqual([])
+    })
+
+    it('returns only mined and not included transactions', async () => {
+      const record1 = fakeRecord(1)
+      const record2 = fakeRecord(2)
+      const record3 = fakeRecord(3)
+      const record4 = fakeRecord(4)
+
+      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
+      await repository.addMined({
+        ...record2,
+        timestamp: Timestamp(2002),
+        blockNumber: 123,
+      })
+      await repository.addMined({
+        ...record3,
+        timestamp: Timestamp(3002),
+        blockNumber: 456,
+      })
+      await repository.addMined({
+        ...record4,
+        timestamp: Timestamp(4002),
+        blockNumber: 789,
+      })
+      await repository.addIncluded({
+        hash: record4.hash,
+        timestamp: Timestamp(4003),
+        blockNumber: 1234,
+        stateUpdateId: 1,
+      })
+
+      const result = await repository.getMinedNotIncluded()
+      expect(result).toEqual([
+        {
+          ...record2,
+          history: [
+            { status: 'sent', timestamp: Timestamp(2001) },
+            { status: 'mined', timestamp: Timestamp(2002), blockNumber: 123 },
+          ],
+        },
+        {
+          ...record3,
+          history: [
+            { status: 'mined', timestamp: Timestamp(3002), blockNumber: 456 },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe(ForcedTradeRepository.prototype.getJustSentHashes.name, () => {
+    it('returns empty array if there are no sent transactions', async () => {
+      const result = await repository.getJustSentHashes()
+      expect(result).toEqual([])
+    })
+
+    it('returns transactions that only have a sent status', async () => {
+      const record1 = fakeRecord(1)
+      const record2 = fakeRecord(2)
+      const record3 = fakeRecord(3)
+      const record4 = fakeRecord(4)
+
+      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
+      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addMined({
+        ...record3,
+        timestamp: Timestamp(3002),
+        blockNumber: 123,
+      })
+      await repository.addMined({
+        ...record4,
+        timestamp: Timestamp(4002),
+        blockNumber: 456,
+      })
+
+      const result = await repository.getJustSentHashes()
+      expect(result).toEqual([record1.hash, record2.hash])
+    })
+  })
+
+  describe(ForcedTradeRepository.prototype.getByPositionId.name, () => {
+    it('returns empty array if there are no transactions', async () => {
+      const result = await repository.getByPositionId(1n)
+      expect(result).toEqual([])
+    })
+
+    it('returns transactions that have the given position id', async () => {
+      const record1 = fakeRecord(1, { positionIdA: 100n, positionIdB: 999n })
+      const record2 = fakeRecord(2, { positionIdA: 200n, positionIdB: 999n })
+      const record3 = fakeRecord(3, { positionIdA: 999n, positionIdB: 200n })
+
+      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
+      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addMined({
+        ...record3,
+        timestamp: Timestamp(3002),
+        blockNumber: 123,
+      })
+
+      const result = await repository.getByPositionId(200n)
+      expect(result).toEqual([
+        {
+          ...record2,
+          history: [{ status: 'sent', timestamp: Timestamp(2001) }],
+        },
+        {
+          ...record3,
+          history: [
+            { status: 'sent', timestamp: Timestamp(3001) },
+            { status: 'mined', timestamp: Timestamp(3002), blockNumber: 123 },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe(ForcedTradeRepository.prototype.getByStarkKey.name, () => {
+    it('returns empty array if there are no transactions', async () => {
+      const result = await repository.getByStarkKey(StarkKey.fake())
+      expect(result).toEqual([])
+    })
+
+    it('returns transactions that have the given stark key id', async () => {
+      const record1 = fakeRecord(1, {
+        starkKeyA: StarkKey.fake('aaa'),
+        starkKeyB: StarkKey.fake('bbb'),
+      })
+      const record2 = fakeRecord(2, {
+        starkKeyA: StarkKey.fake('123'),
+        starkKeyB: StarkKey.fake('bbb'),
+      })
+      const record3 = fakeRecord(3, {
+        starkKeyA: StarkKey.fake('aaa'),
+        starkKeyB: StarkKey.fake('123'),
+      })
+
+      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addSent({ ...record2, timestamp: Timestamp(2001) })
+      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addMined({
+        ...record3,
+        timestamp: Timestamp(3002),
+        blockNumber: 123,
+      })
+
+      const result = await repository.getByStarkKey(StarkKey.fake('123'))
+      expect(result).toEqual([
+        {
+          ...record2,
+          history: [{ status: 'sent', timestamp: Timestamp(2001) }],
+        },
+        {
+          ...record3,
+          history: [
+            { status: 'sent', timestamp: Timestamp(3001) },
+            { status: 'mined', timestamp: Timestamp(3002), blockNumber: 123 },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe(ForcedTradeRepository.prototype.getByStateUpdateId.name, () => {
+    it('returns empty array if there are no transactions', async () => {
+      const result = await repository.getByStateUpdateId(1)
+      expect(result).toEqual([])
+    })
+
+    it('returns transactions that have the given stark key id', async () => {
+      const record1 = fakeRecord(1)
+      const record2 = fakeRecord(2)
+      const record3 = fakeRecord(3)
+      const record4 = fakeRecord(4)
+
+      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addMined({
+        ...record1,
+        timestamp: Timestamp(1002),
+        blockNumber: 102,
+      })
+      await repository.addMined({
+        ...record2,
+        timestamp: Timestamp(2002),
+        blockNumber: 202,
+      })
+      await repository.addIncluded({
+        hash: record2.hash,
+        timestamp: Timestamp(2003),
+        blockNumber: 203,
+        stateUpdateId: 1234,
+      })
+      await repository.addSent({ ...record3, timestamp: Timestamp(3001) })
+      await repository.addMined({
+        ...record3,
+        timestamp: Timestamp(3002),
+        blockNumber: 302,
+      })
+      await repository.addIncluded({
+        hash: record3.hash,
+        timestamp: Timestamp(3003),
+        blockNumber: 303,
+        stateUpdateId: 1234,
+      })
+      await repository.addMined({
+        ...record4,
+        timestamp: Timestamp(4002),
+        blockNumber: 402,
+      })
+      await repository.addIncluded({
+        hash: record4.hash,
+        timestamp: Timestamp(4003),
+        blockNumber: 403,
+        stateUpdateId: 5678,
+      })
+
+      const result = await repository.getByStateUpdateId(1234)
+      expect(result).toEqual([
+        {
+          ...record2,
+          history: [
+            { status: 'mined', timestamp: Timestamp(2002), blockNumber: 202 },
+            {
+              status: 'included',
+              timestamp: Timestamp(2003),
+              blockNumber: 203,
+              stateUpdateId: 1234,
+            },
+          ],
+        },
+        {
+          ...record3,
+          history: [
+            { status: 'sent', timestamp: Timestamp(3001) },
+            { status: 'mined', timestamp: Timestamp(3002), blockNumber: 302 },
+            {
+              status: 'included',
+              timestamp: Timestamp(3003),
+              blockNumber: 303,
+              stateUpdateId: 1234,
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe(ForcedTradeRepository.prototype.deleteAfter.name, () => {
+    it('removes only some transactions', async () => {
+      const record1 = fakeRecord(1)
+      const record2 = fakeRecord(2)
+      const record3 = fakeRecord(3)
+
+      await repository.addSent({ ...record1, timestamp: Timestamp(1001) })
+      await repository.addMined({
+        ...record1,
+        timestamp: Timestamp(1002),
+        blockNumber: 421,
+      })
+      await repository.addMined({
+        ...record2,
+        timestamp: Timestamp(2001),
+        blockNumber: 421,
+      })
+      await repository.addMined({
+        ...record3,
+        timestamp: Timestamp(3002),
+        blockNumber: 420,
+      })
+
+      await repository.deleteAfter(420)
+
+      expect(await repository.findByTransactionHash(record1.hash)).toEqual({
+        ...record1,
+        history: [{ status: 'sent', timestamp: Timestamp(1001) }],
+      })
+      expect(await repository.findByTransactionHash(record2.hash)).toEqual(
+        undefined
+      )
+      expect(await repository.findByTransactionHash(record3.hash)).toEqual({
+        ...record3,
+        history: [
+          { status: 'mined', timestamp: Timestamp(3002), blockNumber: 420 },
+        ],
+      })
+    })
+  })
+})

--- a/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.ts
+++ b/packages/backend/src/peripherals/database/transactions/ForcedTradeRepository.ts
@@ -1,0 +1,385 @@
+import { AssetId, Hash256, StarkKey, Timestamp } from '@explorer/types'
+import {
+  ForcedTradeStatusRow,
+  ForcedTradeTransactionRow,
+} from 'knex/types/tables'
+
+import { Logger } from '../../../tools/Logger'
+import { compareByHistory } from '../../../utils/compareByHistory'
+import { BaseRepository } from '../shared/BaseRepository'
+import { Database } from '../shared/Database'
+
+export interface ForcedTradeTransactionRecord {
+  hash: Hash256
+  starkKeyA: StarkKey
+  starkKeyB: StarkKey
+  positionIdA: bigint
+  positionIdB: bigint
+  collateralAmount: bigint
+  syntheticAmount: bigint
+  isABuyingSynthetic: boolean
+  syntheticAssetId: AssetId
+  nonce: bigint
+}
+
+export interface ForcedTradeTransactionWithHistory
+  extends ForcedTradeTransactionRecord {
+  history: ForcedTradeStatus[]
+}
+
+export type ForcedTradeStatus =
+  | SentStatus
+  | MinedStatus
+  | RevertedStatus
+  | ForgottenStatus
+  | IncludedStatus
+
+export interface SentStatus {
+  status: 'sent'
+  timestamp: Timestamp
+}
+
+export interface MinedStatus {
+  status: 'mined'
+  timestamp: Timestamp
+  blockNumber: number
+}
+
+export interface RevertedStatus {
+  status: 'reverted'
+  timestamp: Timestamp
+  blockNumber: number
+}
+
+export interface ForgottenStatus {
+  status: 'forgotten'
+  timestamp: Timestamp
+}
+
+export interface IncludedStatus {
+  status: 'included'
+  timestamp: Timestamp
+  blockNumber: number
+  stateUpdateId: number
+}
+
+export class ForcedTradeRepository extends BaseRepository {
+  constructor(database: Database, logger: Logger) {
+    super(database, logger)
+
+    /* eslint-disable @typescript-eslint/unbound-method */
+
+    this.addSent = this.wrapAdd(this.addSent)
+    this.addMined = this.wrapAdd(this.addMined)
+    this.addReverted = this.wrapAdd(this.addReverted)
+    this.addForgotten = this.wrapAdd(this.addForgotten)
+    this.addIncluded = this.wrapAdd(this.addIncluded)
+    this.findByTransactionHash = this.wrapFind(this.findByTransactionHash)
+    // this.findByOfferId = this.wrapFind(this.findByOfferId)
+    this.getByPositionId = this.wrapGet(this.getByPositionId)
+    this.getByStarkKey = this.wrapGet(this.getByStarkKey)
+    this.getByStateUpdateId = this.wrapGet(this.getByStateUpdateId)
+    this.getMinedNotIncluded = this.wrapGet(this.getMinedNotIncluded)
+    this.getJustSentHashes = this.wrapGet(this.getJustSentHashes)
+    this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.deleteAfter = this.wrapDelete(this.deleteAfter)
+
+    /* eslint-enable @typescript-eslint/unbound-method */
+  }
+
+  async addSent(
+    record: ForcedTradeTransactionRecord & { timestamp: Timestamp }
+  ): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex.transaction(async (trx) => {
+      await trx('forced_trade_transactions')
+        .insert(toRow(record))
+        .onConflict('hash')
+        .ignore()
+      await trx('forced_trade_statuses').insert({
+        hash: record.hash.toString(),
+        status: 'sent',
+        timestamp: BigInt(record.timestamp.toString()),
+      })
+    })
+    return record.hash
+  }
+
+  async addMined(
+    record: ForcedTradeTransactionRecord & {
+      timestamp: Timestamp
+      blockNumber: number
+    }
+  ): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex.transaction(async (trx) => {
+      await trx('forced_trade_transactions')
+        .insert(toRow(record))
+        .onConflict('hash')
+        .ignore()
+      await trx('forced_trade_statuses').insert({
+        hash: record.hash.toString(),
+        status: 'mined',
+        timestamp: BigInt(record.timestamp.toString()),
+        block_number: record.blockNumber,
+      })
+    })
+    return record.hash
+  }
+
+  async addReverted(status: {
+    hash: Hash256
+    timestamp: Timestamp
+    blockNumber: number
+  }): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex('forced_trade_statuses').insert({
+      hash: status.hash.toString(),
+      status: 'reverted',
+      timestamp: BigInt(status.timestamp.toString()),
+      block_number: status.blockNumber,
+    })
+    return status.hash
+  }
+
+  async addForgotten(status: {
+    hash: Hash256
+    timestamp: Timestamp
+  }): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex('forced_trade_statuses').insert({
+      hash: status.hash.toString(),
+      status: 'forgotten',
+      timestamp: BigInt(status.timestamp.toString()),
+    })
+    return status.hash
+  }
+
+  async addIncluded(status: {
+    hash: Hash256
+    timestamp: Timestamp
+    blockNumber: number
+    stateUpdateId: number
+  }): Promise<Hash256> {
+    const knex = await this.knex()
+    await knex('forced_trade_statuses').insert({
+      hash: status.hash.toString(),
+      status: 'included',
+      timestamp: BigInt(status.timestamp.toString()),
+      block_number: status.blockNumber,
+      state_update_id: status.stateUpdateId,
+    })
+    return status.hash
+  }
+
+  async findByTransactionHash(
+    hash: Hash256
+  ): Promise<ForcedTradeTransactionWithHistory | undefined> {
+    const knex = await this.knex()
+    const row = await knex('forced_trade_transactions')
+      .where('hash', hash.toString())
+      .first()
+    if (!row) {
+      return undefined
+    }
+    const record = toRecord(row)
+    const [result] = await this.recordsWithHistories([record])
+    return result
+  }
+
+  async getByPositionId(
+    positionId: bigint
+  ): Promise<ForcedTradeTransactionWithHistory[]> {
+    const knex = await this.knex()
+    const rows = await knex('forced_trade_transactions')
+      .where('position_id_a', positionId)
+      .orWhere('position_id_b', positionId)
+    const records = rows.map(toRecord)
+    const results = await this.recordsWithHistories(records)
+    return results.sort(compareByHistory)
+  }
+
+  async getByStarkKey(
+    starkKey: StarkKey
+  ): Promise<ForcedTradeTransactionWithHistory[]> {
+    const knex = await this.knex()
+    const rows = await knex('forced_trade_transactions')
+      .where('stark_key_a', starkKey.toString())
+      .orWhere('stark_key_b', starkKey.toString())
+    const records = rows.map(toRecord)
+    const results = await this.recordsWithHistories(records)
+    return results.sort(compareByHistory)
+  }
+
+  async getByStateUpdateId(
+    stateUpdateId: number
+  ): Promise<ForcedTradeTransactionWithHistory[]> {
+    const knex = await this.knex()
+    const rows = await knex('forced_trade_statuses')
+      .where({
+        status: 'included',
+        state_update_id: stateUpdateId,
+      })
+      .join(
+        'forced_trade_transactions',
+        'forced_trade_statuses.hash',
+        '=',
+        'forced_trade_transactions.hash'
+      )
+      .select('forced_trade_transactions.*')
+    const records = rows.map(toRecord)
+    const results = await this.recordsWithHistories(records)
+    return results.sort(compareByHistory)
+  }
+
+  async getMinedNotIncluded(): Promise<ForcedTradeTransactionWithHistory[]> {
+    const knex = await this.knex()
+    const { rows } = (await knex.raw(`
+      SELECT t.* FROM forced_trade_statuses a
+      JOIN forced_trade_transactions t
+      ON t.hash = a.hash
+      WHERE a.status = 'mined'
+      AND NOT EXISTS (
+        SELECT 1 FROM forced_trade_statuses b
+        WHERE b.hash = a.hash
+        AND b.status = 'included'
+      )
+      ORDER BY a.timestamp ASC
+    `)) as unknown as { rows: ForcedTradeTransactionRow[] }
+    const records = rows.map(toRecord)
+    const results = await this.recordsWithHistories(records)
+    return results
+  }
+
+  async getJustSentHashes(): Promise<Hash256[]> {
+    const knex = await this.knex()
+    const { rows } = (await knex.raw(`
+      SELECT a.hash FROM forced_trade_statuses a
+      WHERE a.status = 'sent'
+      AND NOT EXISTS (
+        SELECT 1 FROM forced_trade_statuses b
+        WHERE b.hash = a.hash
+        AND b.status != 'sent'
+      )
+      ORDER BY a.timestamp ASC
+    `)) as unknown as { rows: { hash: string }[] }
+    return rows.map((row) => Hash256(row.hash))
+  }
+
+  private async recordsWithHistories(
+    records: ForcedTradeTransactionRecord[]
+  ): Promise<ForcedTradeTransactionWithHistory[]> {
+    if (records.length === 0) {
+      return []
+    }
+    const knex = await this.knex()
+    const rows = await knex('forced_trade_statuses')
+      .whereIn(
+        'hash',
+        records.map((x) => x.hash.toString())
+      )
+      .orderBy('timestamp', 'asc')
+    return records
+      .map((record) => ({
+        ...record,
+        history: rows
+          .filter((x) => x.hash === record.hash.toString())
+          .map(toHistoryRow),
+      }))
+      .filter((x) => x.history.length > 0)
+  }
+
+  async deleteAll() {
+    const knex = await this.knex()
+    const countA = await knex('forced_trade_transactions').delete()
+    const countB = await knex('forced_trade_statuses').delete()
+    return countA + countB
+  }
+
+  async deleteAfter(blockNumber: number) {
+    const knex = await this.knex()
+    return await knex('forced_trade_statuses')
+      .where('block_number', '>', blockNumber)
+      .delete()
+  }
+}
+
+function toRecord(
+  row: ForcedTradeTransactionRow
+): ForcedTradeTransactionRecord {
+  return {
+    hash: Hash256(row.hash),
+    starkKeyA: StarkKey(row.stark_key_a),
+    starkKeyB: StarkKey(row.stark_key_b),
+    positionIdA: row.position_id_a,
+    positionIdB: row.position_id_b,
+    collateralAmount: row.collateral_amount,
+    syntheticAmount: row.synthetic_amount,
+    isABuyingSynthetic: row.is_a_buying_synthetic,
+    syntheticAssetId: AssetId(row.synthetic_asset_id),
+    nonce: row.nonce,
+  }
+}
+
+function toRow(
+  record: ForcedTradeTransactionRecord
+): ForcedTradeTransactionRow {
+  return {
+    hash: record.hash.toString(),
+    stark_key_a: record.starkKeyA.toString(),
+    stark_key_b: record.starkKeyB.toString(),
+    position_id_a: record.positionIdA,
+    position_id_b: record.positionIdB,
+    collateral_amount: record.collateralAmount,
+    synthetic_amount: record.syntheticAmount,
+    is_a_buying_synthetic: record.isABuyingSynthetic,
+    synthetic_asset_id: record.syntheticAssetId.toString(),
+    nonce: record.nonce,
+  }
+}
+
+function toHistoryRow(row: ForcedTradeStatusRow): ForcedTradeStatus {
+  switch (row.status) {
+    case 'sent':
+      return {
+        status: 'sent',
+        timestamp: Timestamp(row.timestamp),
+      }
+    case 'mined':
+      if (row.block_number == null) {
+        throw new Error('Corrupt database: block_number is null')
+      }
+      return {
+        status: 'mined',
+        timestamp: Timestamp(row.timestamp),
+        blockNumber: row.block_number,
+      }
+    case 'reverted':
+      if (row.block_number == null) {
+        throw new Error('Corrupt database: block_number is null')
+      }
+      return {
+        status: 'reverted',
+        timestamp: Timestamp(row.timestamp),
+        blockNumber: row.block_number,
+      }
+    case 'forgotten':
+      return {
+        status: 'forgotten',
+        timestamp: Timestamp(row.timestamp),
+      }
+    case 'included':
+      if (row.block_number == null) {
+        throw new Error('Corrupt database: block_number is null')
+      }
+      if (row.state_update_id == null) {
+        throw new Error('Corrupt database: state_update_id is null')
+      }
+      return {
+        status: 'included',
+        timestamp: Timestamp(row.timestamp),
+        blockNumber: row.block_number,
+        stateUpdateId: row.state_update_id,
+      }
+  }
+}

--- a/packages/backend/src/peripherals/database/transactions/ForcedWithdrawRepository.test.ts
+++ b/packages/backend/src/peripherals/database/transactions/ForcedWithdrawRepository.test.ts
@@ -1,8 +1,8 @@
 import { Hash256, StarkKey, Timestamp } from '@explorer/types'
 import { expect } from 'earljs'
 
-import { setupDatabaseTestSuite } from '../../test/database'
-import { Logger } from '../../tools/Logger'
+import { setupDatabaseTestSuite } from '../../../test/database'
+import { Logger } from '../../../tools/Logger'
 import {
   ForcedWithdrawRepository,
   ForcedWithdrawTransactionRecord,

--- a/packages/backend/src/peripherals/database/transactions/ForcedWithdrawRepository.ts
+++ b/packages/backend/src/peripherals/database/transactions/ForcedWithdrawRepository.ts
@@ -4,10 +4,10 @@ import {
   ForcedWithdrawTransactionRow,
 } from 'knex/types/tables'
 
-import { Logger } from '../../tools/Logger'
-import { compareByHistory } from '../../utils/compareByHistory'
-import { BaseRepository } from './shared/BaseRepository'
-import { Database } from './shared/Database'
+import { Logger } from '../../../tools/Logger'
+import { compareByHistory } from '../../../utils/compareByHistory'
+import { BaseRepository } from '../shared/BaseRepository'
+import { Database } from '../shared/Database'
 
 export interface ForcedWithdrawTransactionRecord {
   hash: Hash256


### PR DESCRIPTION
Resolves L2B-637

This new repository is almost identical to ForcedWithdrawRepository with some key differences
1. It uses a different record data structure
2. `SentStatus` has an `offerId` field
3. a new method `findByOfferId` is added
4. searching by position id or stark key matches either of the two available fields