### PR TITLE
Generic preprocessor syncing logic with reorg handling

### DIFF
--- a/packages/backend/src/core/preprocessing/Preprocessor.test.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.test.ts
@@ -40,7 +40,7 @@ describe(Preprocessor.name, () => {
       ]
       let index = 0
       preprocessor.calculateRequiredSyncDirection = async () => {
-        return directions[index++] ?? 'not-needed'
+        return directions[index++] ?? 'stop'
       }
 
       const actualCalls: SyncDirection[] = []
@@ -70,7 +70,7 @@ describe(Preprocessor.name, () => {
         Logger.SILENT
       )
       expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
-        'not-needed'
+        'stop'
       )
     })
 
@@ -173,7 +173,7 @@ describe(Preprocessor.name, () => {
         Logger.SILENT
       )
       expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
-        'not-needed'
+        'stop'
       )
     })
 

--- a/packages/backend/src/core/preprocessing/Preprocessor.test.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.test.ts
@@ -1,0 +1,248 @@
+import { Hash256, PedersenHash, Timestamp } from '@explorer/types'
+import { expect } from 'earljs'
+
+import { PreprocessedStateUpdateRepository } from '../../peripherals/database/PreprocessedStateUpdateRepository'
+import {
+  StateUpdateRecord,
+  StateUpdateRepository,
+} from '../../peripherals/database/StateUpdateRepository'
+import { mock } from '../../test/mock'
+import { Logger } from '../../tools/Logger'
+import { Preprocessor, SyncDirection } from './Preprocessor'
+
+const generateFakePosition = (state_update_id: number): StateUpdateRecord => ({
+  id: state_update_id,
+  blockNumber: 10_000 + state_update_id,
+  rootHash: PedersenHash.fake(),
+  stateTransitionHash: Hash256.fake(),
+  timestamp: Timestamp(0),
+})
+
+describe(Preprocessor.name, () => {
+  describe(Preprocessor.prototype.sync.name, () => {
+    it('correctly moves forward and backward', async () => {
+      const preprocessor = new Preprocessor(
+        mock<PreprocessedStateUpdateRepository>(),
+        mock<StateUpdateRepository>(),
+        Logger.SILENT
+      )
+
+      const directions: SyncDirection[] = [
+        'forward',
+        'forward',
+        'backward',
+        'forward',
+        'backward',
+        'backward',
+      ]
+      let index = 0
+      preprocessor.calculateRequiredSyncDirection = async () => {
+        return directions[index++] ?? 'not-needed'
+      }
+
+      const actualCalls: SyncDirection[] = []
+      preprocessor.processNextStateUpdate = async () => {
+        actualCalls.push('forward')
+      }
+      preprocessor.rollbackOneStateUpdate = async () => {
+        actualCalls.push('backward')
+      }
+
+      await preprocessor.sync()
+      expect(actualCalls).toEqual(directions)
+    })
+  })
+
+  describe(Preprocessor.prototype.calculateRequiredSyncDirection.name, () => {
+    it('returns not-needed when everything is empty', async () => {
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findLast: async () => undefined,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        // findLast: async () => ({ stateUpdateId: 3, stateTransitionHash: Hash256.fake()}),
+        findLast: async () => undefined,
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'not-needed'
+      )
+    })
+
+    it('returns backward when there are no state updates but preprocessing has entries', async () => {
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findLast: async () => undefined,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: 3,
+          stateTransitionHash: Hash256.fake(),
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'backward'
+      )
+    })
+
+    it('returns forward when there are state updates but preprocessing has no entries', async () => {
+      const fakePosition = generateFakePosition(3)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findLast: async () => fakePosition,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => undefined,
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'forward'
+      )
+    })
+
+    it('returns backward when state update id is before preprocessing', async () => {
+      const fakePosition = generateFakePosition(2)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findLast: async () => fakePosition,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: fakePosition.id + 1,
+          stateTransitionHash: Hash256.fake(),
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'backward'
+      )
+    })
+
+    it("throws when the are more state updates but can't find preprocessed id", async () => {
+      const fakePosition = generateFakePosition(10)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findById: async () => undefined,
+        findLast: async () => fakePosition,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: fakePosition.id - 1,
+          stateTransitionHash: Hash256.fake(),
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      await expect(preprocessor.calculateRequiredSyncDirection()).toBeRejected(
+        'Missing expected state update during Preprocessor sync'
+      )
+    })
+
+    it('returns not-needed when last state update ids and transition hashes match', async () => {
+      const fakePosition = generateFakePosition(10)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findById: async (id: number) => ({ [10]: fakePosition }[id]),
+        findLast: async () => fakePosition,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: fakePosition.id,
+          stateTransitionHash: fakePosition.stateTransitionHash,
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'not-needed'
+      )
+    })
+
+    // This can happen when there was a reorg and then a few more state updates were added
+    it('returns backward when last state update ids match but transition hash is mismatched', async () => {
+      const fakePosition = generateFakePosition(10)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findById: async (id: number) => ({ [10]: fakePosition }[id]),
+        findLast: async () => fakePosition,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: fakePosition.id,
+          stateTransitionHash: Hash256.fake(),
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'backward'
+      )
+    })
+
+    // This can happen when there was a reorg and then a few more state updates were added
+    it('returns backward when state is ahead of preprocessing but current transition hash is mismatched', async () => {
+      const fakePosition5 = generateFakePosition(5)
+      const fakePosition10 = generateFakePosition(10)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findById: async (id: number) => ({ [5]: fakePosition5 }[id]),
+        findLast: async () => fakePosition10,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: 5,
+          stateTransitionHash: Hash256.fake(),
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'backward'
+      )
+    })
+
+    it('returns forward when state is ahead and current transition hash matches', async () => {
+      const fakePosition5 = generateFakePosition(5)
+      const fakePosition10 = generateFakePosition(10)
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findById: async (id: number) => ({ [5]: fakePosition5 }[id]),
+        findLast: async () => fakePosition10,
+      })
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => ({
+          stateUpdateId: 5,
+          stateTransitionHash: fakePosition5.stateTransitionHash,
+        }),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
+        'forward'
+      )
+    })
+  })
+})

--- a/packages/backend/src/core/preprocessing/Preprocessor.test.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.test.ts
@@ -327,5 +327,21 @@ describe(Preprocessor.name, () => {
         mockKnexTransaction,
       ])
     })
+
+    it('throws when there are no preprocessings to roll back', async () => {
+      const mockKnexTransaction = mock<Knex.Transaction>()
+      const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
+        findLast: async () => undefined,
+        runInTransaction: async (fn) => fn(mockKnexTransaction),
+      })
+      const preprocessor = new Preprocessor(
+        preprocessedRepo,
+        mock<StateUpdateRepository>(),
+        Logger.SILENT
+      )
+      await expect(preprocessor.rollbackOneStateUpdate()).toBeRejected(
+        'Preprocessing rollback was requested, but there is nothing to roll back'
+      )
+    })
   })
 })

--- a/packages/backend/src/core/preprocessing/Preprocessor.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.ts
@@ -126,7 +126,9 @@ export class Preprocessor {
           await this.preprocessedStateUpdateRepository.findLast(trx)
 
         if (lastProcessedStateUpdate === undefined) {
-          return
+          throw new Error(
+            'Preprocessing rollback was requested, but there is nothing to roll back'
+          )
         }
 
         this.logger.info(

--- a/packages/backend/src/core/preprocessing/Preprocessor.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.ts
@@ -89,12 +89,16 @@ export class Preprocessor {
 
         const lastProcessedStateUpdate =
           await this.preprocessedStateUpdateRepository.findLast(trx)
+        const nextStateUpdateId =
+          (lastProcessedStateUpdate?.stateUpdateId ?? 0) + 1
         const nextStateUpdate = await this.stateUpdateRepository.findById(
-          (lastProcessedStateUpdate?.stateUpdateId ?? 0) + 1,
+          nextStateUpdateId,
           trx
         )
         if (nextStateUpdate === undefined) {
-          return
+          throw new Error(
+            `Preprocessing was requested, but next state update (${nextStateUpdateId}) is missing`
+          )
         }
 
         this.logger.info(`Preprocessing state update ${nextStateUpdate.id}`)

--- a/packages/backend/src/core/preprocessing/Preprocessor.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.ts
@@ -1,0 +1,86 @@
+import { PreprocessedStateUpdateRepository } from '../../peripherals/database/PreprocessedStateUpdateRepository'
+import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
+import { Logger } from '../../tools/Logger'
+
+type SyncDirection = 'forward' | 'backward' | 'not-needed'
+
+export class Preprocessor {
+  constructor(
+    private preprocessedStateUpdateRepository: PreprocessedStateUpdateRepository,
+    private stateUpdateRepository: StateUpdateRepository,
+    private logger: Logger
+  ) {
+    this.logger = this.logger.for(this)
+  }
+
+  async sync() {
+    let direction
+    do {
+      direction = await this.calculateRequiredSyncDirection()
+      if (direction === 'forward') {
+        await this.processNextStateUpdate()
+      } else if (direction === 'backward') {
+        await this.rollbackOneStateUpdate()
+      }
+    } while (direction !== 'not-needed')
+  }
+
+  // Preprocessor can move only one state-update forward or backward. This
+  // function returns the required direction of the next move.
+  //
+  // It's not enough to just compare the last processed-state-update id with the
+  // last state-update id because if reorg has happened, state-update id might
+  // have caught up and be the same (it's a sequential number).
+  //
+  // That's why state transition hash is also compared.  In general, this
+  // function moves backward until it finds a "common" state update, with the
+  // same id and state transition hash. Then it moves forward.
+  async calculateRequiredSyncDirection(): Promise<SyncDirection> {
+    const lastStateUpdate = await this.stateUpdateRepository.findLast()
+    const lastProcessedStateUpdate =
+      await this.preprocessedStateUpdateRepository.findLast()
+
+    // 1. Handle simple cases of empty state updates and empty preprocessed
+    // state updates.
+
+    if (lastStateUpdate === undefined) {
+      return lastProcessedStateUpdate === undefined ? 'not-needed' : 'backward'
+    }
+    if (lastProcessedStateUpdate === undefined) {
+      return 'forward'
+    }
+
+    // 2. Move back when current id is behind or there's hash mismatch,
+    // (due to reorg), or throw on missing state update.
+
+    if (lastStateUpdate.id < lastProcessedStateUpdate.stateUpdateId) {
+      return 'backward'
+    }
+
+    const actualStateUpdate = await this.stateUpdateRepository.findById(
+      lastProcessedStateUpdate.stateUpdateId
+    )
+    if (actualStateUpdate === undefined) {
+      throw new Error('Missing expected state update during Preprocessor sync')
+    }
+
+    if (
+      actualStateUpdate.stateTransitionHash !==
+      lastProcessedStateUpdate.stateTransitionHash
+    ) {
+      // Reorg happened
+      return 'backward'
+    }
+
+    // 3. If all is ok and we're behind, move forward
+
+    if (lastStateUpdate.id > lastProcessedStateUpdate.stateUpdateId) {
+      return 'forward'
+    }
+
+    return 'not-needed'
+  }
+
+  async processNextStateUpdate() {}
+  async rollbackOneStateUpdate() {}
+}

--- a/packages/backend/src/core/preprocessing/Preprocessor.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.ts
@@ -2,7 +2,7 @@ import { PreprocessedStateUpdateRepository } from '../../peripherals/database/Pr
 import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
 import { Logger } from '../../tools/Logger'
 
-type SyncDirection = 'forward' | 'backward' | 'not-needed'
+export type SyncDirection = 'forward' | 'backward' | 'not-needed'
 
 export class Preprocessor {
   constructor(

--- a/packages/backend/src/core/preprocessing/Preprocessor.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.ts
@@ -2,7 +2,7 @@ import { PreprocessedStateUpdateRepository } from '../../peripherals/database/Pr
 import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
 import { Logger } from '../../tools/Logger'
 
-export type SyncDirection = 'forward' | 'backward' | 'not-needed'
+export type SyncDirection = 'forward' | 'backward' | 'stop'
 
 export class Preprocessor {
   constructor(
@@ -23,7 +23,7 @@ export class Preprocessor {
       } else if (direction === 'backward') {
         await this.rollbackOneStateUpdate()
       }
-    } while (direction !== 'not-needed')
+    } while (direction !== 'stop')
   }
 
   // Preprocessor can move only one state-update forward or backward. This
@@ -45,7 +45,7 @@ export class Preprocessor {
     // state updates.
 
     if (lastStateUpdate === undefined) {
-      return lastProcessedStateUpdate === undefined ? 'not-needed' : 'backward'
+      return lastProcessedStateUpdate === undefined ? 'stop' : 'backward'
     }
     if (lastProcessedStateUpdate === undefined) {
       return 'forward'
@@ -79,7 +79,7 @@ export class Preprocessor {
       return 'forward'
     }
 
-    return 'not-needed'
+    return 'stop'
   }
 
   async processNextStateUpdate() {

--- a/packages/backend/src/peripherals/database/KeyValueStore.ts
+++ b/packages/backend/src/peripherals/database/KeyValueStore.ts
@@ -1,3 +1,4 @@
+import { Knex } from 'knex'
 import { KeyValueRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
@@ -24,8 +25,8 @@ export class KeyValueStore extends BaseRepository {
     /* eslint-enable @typescript-eslint/unbound-method */
   }
 
-  async findByKey(key: string): Promise<string | undefined> {
-    const knex = await this.knex()
+  async findByKey(key: string, trx?: Knex.Transaction): Promise<string | undefined> {
+    const knex = await this.knex(trx)
     const row = await knex('key_values').select('value').where({ key }).first()
     return row?.value
   }

--- a/packages/backend/src/peripherals/database/KeyValueStore.ts
+++ b/packages/backend/src/peripherals/database/KeyValueStore.ts
@@ -25,7 +25,10 @@ export class KeyValueStore extends BaseRepository {
     /* eslint-enable @typescript-eslint/unbound-method */
   }
 
-  async findByKey(key: string, trx?: Knex.Transaction): Promise<string | undefined> {
+  async findByKey(
+    key: string,
+    trx?: Knex.Transaction
+  ): Promise<string | undefined> {
     const knex = await this.knex(trx)
     const row = await knex('key_values').select('value').where({ key }).first()
     return row?.value

--- a/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.test.ts
@@ -1,0 +1,47 @@
+import { Hash256 } from '@explorer/types'
+import { expect } from 'earljs'
+
+import { setupDatabaseTestSuite } from '../../test/database'
+import { Logger, LogLevel } from '../../tools/Logger'
+import { PreprocessedStateUpdateRepository, } from './PreprocessedStateUpdateRepository'
+
+describe(PreprocessedStateUpdateRepository.name, () => {
+  const { database } = setupDatabaseTestSuite()
+
+  const repository = new PreprocessedStateUpdateRepository(
+    database,
+    new Logger({ format: 'pretty', logLevel: LogLevel.ERROR })
+  )
+
+  beforeEach(() => repository.deleteAll())
+
+  it('adds preprocessed state update', async () => {
+    await repository.add({
+      stateUpdateId: 10_000,
+      stateTransitionHash: Hash256.fake(),
+    })
+  })
+
+
+  it('gets last state update by id', async () => {
+    let last = await repository.findLast()
+
+    expect(last).toEqual(undefined)
+
+    for (const blockNumber of [30_001, 30_002, 30_003]) {
+      await repository.add({
+        stateUpdateId: blockNumber * 1000,
+        stateTransitionHash: Hash256.fake(),
+      })
+    }
+    const stateUpdate = {
+      stateUpdateId: 30_004_000,
+      stateTransitionHash: Hash256.fake(),
+    }
+    await repository.add(stateUpdate)
+
+    last = await repository.findLast()
+
+    expect(last).toEqual(stateUpdate)
+  })
+})

--- a/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.test.ts
@@ -43,4 +43,17 @@ describe(PreprocessedStateUpdateRepository.name, () => {
 
     expect(last).toEqual(stateUpdate)
   })
+
+  it('removes by state update id', async () => {
+    for (const blockNumber of [30_001, 30_002, 30_003]) {
+      await repository.add({
+        stateUpdateId: blockNumber * 1000,
+        stateTransitionHash: Hash256.fake(),
+      })
+    }
+
+    await repository.deleteByStateUpdateId(30_003_000)
+
+    expect((await repository.findLast())?.stateUpdateId).toEqual(30_002_000)
+  })
 })

--- a/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
 import { Logger, LogLevel } from '../../tools/Logger'
-import { PreprocessedStateUpdateRepository, } from './PreprocessedStateUpdateRepository'
+import { PreprocessedStateUpdateRepository } from './PreprocessedStateUpdateRepository'
 
 describe(PreprocessedStateUpdateRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
@@ -21,7 +21,6 @@ describe(PreprocessedStateUpdateRepository.name, () => {
       stateTransitionHash: Hash256.fake(),
     })
   })
-
 
   it('gets last state update by id', async () => {
     let last = await repository.findLast()

--- a/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.ts
@@ -1,0 +1,67 @@
+import { Hash256 } from '@explorer/types'
+import { Knex } from 'knex'
+import { PreprocessedStateUpdateRow } from 'knex/types/tables'
+
+import { Logger } from '../../tools/Logger'
+import { BaseRepository } from './shared/BaseRepository'
+import { Database } from './shared/Database'
+
+export interface PreprocessedStateUpdateRecord {
+  stateUpdateId: number
+  stateTransitionHash: Hash256
+}
+
+export class PreprocessedStateUpdateRepository extends BaseRepository {
+  constructor(database: Database, logger: Logger) {
+    super(database, logger)
+
+    /* eslint-disable @typescript-eslint/unbound-method */
+    this.add = this.wrapAdd(this.add)
+    this.findLast = this.wrapFind(this.findLast)
+    this.deleteAll = this.wrapDelete(this.deleteAll)
+    /* eslint-enable @typescript-eslint/unbound-method */
+  }
+
+  async findLast(
+    trx?: Knex.Transaction
+  ): Promise<PreprocessedStateUpdateRecord | undefined> {
+    const knex = await this.knex(trx)
+    const row = await knex('preprocessed_state_updates')
+      .orderBy('state_update_id', 'desc')
+      .first()
+    return row && toPreprocessedStateUpdateRecord(row)
+  }
+
+  async add(
+    row: PreprocessedStateUpdateRecord,
+    trx?: Knex.Transaction
+  ): Promise<number> {
+    const knex = await this.knex(trx)
+    await knex('preprocessed_state_updates')
+      .insert(toPreprocessedStateUpdateRow(row))
+    return row.stateUpdateId
+  }
+
+  async deleteAll() {
+    const knex = await this.knex()
+    return knex('preprocessed_state_updates').delete()
+  }
+}
+
+function toPreprocessedStateUpdateRecord(
+  row: PreprocessedStateUpdateRow
+): PreprocessedStateUpdateRecord {
+  return {
+    stateUpdateId: row.state_update_id,
+    stateTransitionHash: Hash256(row.state_transition_hash),
+  }
+}
+
+function toPreprocessedStateUpdateRow(
+  record: PreprocessedStateUpdateRecord
+): PreprocessedStateUpdateRow {
+  return {
+    state_update_id: record.stateUpdateId,
+    state_transition_hash: record.stateTransitionHash.toString()
+  }
+}

--- a/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.ts
@@ -37,8 +37,9 @@ export class PreprocessedStateUpdateRepository extends BaseRepository {
     trx?: Knex.Transaction
   ): Promise<number> {
     const knex = await this.knex(trx)
-    await knex('preprocessed_state_updates')
-      .insert(toPreprocessedStateUpdateRow(row))
+    await knex('preprocessed_state_updates').insert(
+      toPreprocessedStateUpdateRow(row)
+    )
     return row.stateUpdateId
   }
 
@@ -62,6 +63,6 @@ function toPreprocessedStateUpdateRow(
 ): PreprocessedStateUpdateRow {
   return {
     state_update_id: record.stateUpdateId,
-    state_transition_hash: record.stateTransitionHash.toString()
+    state_transition_hash: record.stateTransitionHash.toString(),
   }
 }

--- a/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/PreprocessedStateUpdateRepository.ts
@@ -19,6 +19,7 @@ export class PreprocessedStateUpdateRepository extends BaseRepository {
     this.add = this.wrapAdd(this.add)
     this.findLast = this.wrapFind(this.findLast)
     this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.deleteByStateUpdateId = this.wrapDelete(this.deleteByStateUpdateId)
     /* eslint-enable @typescript-eslint/unbound-method */
   }
 
@@ -43,9 +44,16 @@ export class PreprocessedStateUpdateRepository extends BaseRepository {
     return row.stateUpdateId
   }
 
-  async deleteAll() {
-    const knex = await this.knex()
+  async deleteAll(trx?: Knex.Transaction) {
+    const knex = await this.knex(trx)
     return knex('preprocessed_state_updates').delete()
+  }
+
+  async deleteByStateUpdateId(stateUpdateId: number, trx?: Knex.Transaction) {
+    const knex = await this.knex(trx)
+    return knex('preprocessed_state_updates')
+      .where('state_update_id', stateUpdateId)
+      .delete()
   }
 }
 

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.test.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.test.ts
@@ -133,6 +133,40 @@ describe(StateUpdateRepository.name, () => {
     expect(last).toEqual(stateUpdate)
   })
 
+  it('find state update by id', async () => {
+    let last = await repository.findById(30_002)
+    expect(last).toEqual(undefined)
+
+    const stateUpdate1 = {
+      id: 30_001_000,
+      blockNumber: 30_001,
+      rootHash: PedersenHash.fake(),
+      stateTransitionHash: Hash256.fake(),
+      timestamp: Timestamp(0),
+    }
+    const stateUpdate2 = {
+      id: 30_002_000,
+      blockNumber: 30_002,
+      rootHash: PedersenHash.fake(),
+      stateTransitionHash: Hash256.fake(),
+      timestamp: Timestamp(0),
+    }
+    await repository.add({
+      stateUpdate: stateUpdate1,
+      positions: [],
+      prices: [],
+    })
+    await repository.add({
+      stateUpdate: stateUpdate2,
+      positions: [],
+      prices: [],
+    })
+
+    last = await repository.findById(30_001_000)
+
+    expect(last).toEqual(stateUpdate1)
+  })
+
   it('gets last state update by id even if block number is the same', async () => {
     let last = await repository.findLast()
     expect(last).toEqual(undefined)

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -34,6 +34,7 @@ export class StateUpdateRepository extends BaseRepository {
 
     this.add = this.wrapAdd(this.add)
     this.findLast = this.wrapFind(this.findLast)
+    this.findById = this.wrapFind(this.findById)
     this.findIdByRootHash = this.wrapFind(this.findIdByRootHash)
     this.getAll = this.wrapGet(this.getAll)
     this.getPaginated = this.wrapGet(this.getPaginated)
@@ -82,6 +83,12 @@ export class StateUpdateRepository extends BaseRepository {
   async findLast(): Promise<StateUpdateRecord | undefined> {
     const knex = await this.knex()
     const row = await knex('state_updates').orderBy('id', 'desc').first()
+    return row && toStateUpdateRecord(row)
+  }
+
+  async findById(id: number): Promise<StateUpdateRecord | undefined> {
+    const knex = await this.knex()
+    const row = await knex('state_updates').where('id', id).first()
     return row && toStateUpdateRecord(row)
   }
 

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -1,5 +1,6 @@
 import { OraclePrice } from '@explorer/encoding'
 import { AssetId, Hash256, PedersenHash, Timestamp } from '@explorer/types'
+import { Knex } from 'knex'
 import { PriceRow, StateUpdateRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
@@ -86,8 +87,11 @@ export class StateUpdateRepository extends BaseRepository {
     return row && toStateUpdateRecord(row)
   }
 
-  async findById(id: number): Promise<StateUpdateRecord | undefined> {
-    const knex = await this.knex()
+  async findById(
+    id: number,
+    trx?: Knex.Transaction
+  ): Promise<StateUpdateRecord | undefined> {
+    const knex = await this.knex(trx)
     const row = await knex('state_updates').where('id', id).first()
     return row && toStateUpdateRecord(row)
   }

--- a/packages/backend/src/peripherals/database/SyncStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/SyncStatusRepository.test.ts
@@ -26,7 +26,10 @@ describe(SyncStatusRepository.name, () => {
 
     const actual = await repository.getLastSynced()
     expect(actual).toEqual(20)
-    expect(store.findByKey).toHaveBeenCalledWith(['lastBlockNumberSynced', undefined])
+    expect(store.findByKey).toHaveBeenCalledWith([
+      'lastBlockNumberSynced',
+      undefined,
+    ])
   })
 
   it('returns undefined when store is empty', async () => {

--- a/packages/backend/src/peripherals/database/SyncStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/SyncStatusRepository.test.ts
@@ -26,7 +26,7 @@ describe(SyncStatusRepository.name, () => {
 
     const actual = await repository.getLastSynced()
     expect(actual).toEqual(20)
-    expect(store.findByKey).toHaveBeenCalledWith(['lastBlockNumberSynced'])
+    expect(store.findByKey).toHaveBeenCalledWith(['lastBlockNumberSynced', undefined])
   })
 
   it('returns undefined when store is empty', async () => {

--- a/packages/backend/src/peripherals/database/SyncStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/SyncStatusRepository.ts
@@ -1,3 +1,5 @@
+import { Knex } from 'knex'
+
 import { Logger } from '../../tools/Logger'
 import type { KeyValueStore } from './KeyValueStore'
 
@@ -9,8 +11,8 @@ export class SyncStatusRepository {
     this.logger = this.logger.for(this)
   }
 
-  async getLastSynced(): Promise<number | undefined> {
-    const valueInDb = await this.store.findByKey('lastBlockNumberSynced')
+  async getLastSynced(trx?: Knex.Transaction): Promise<number | undefined> {
+    const valueInDb = await this.store.findByKey('lastBlockNumberSynced', trx)
     if (valueInDb) {
       const result = Number(valueInDb)
       if (!isNaN(result)) {

--- a/packages/backend/src/peripherals/database/migrations/026_preprocessed_state_updates.ts
+++ b/packages/backend/src/peripherals/database/migrations/026_preprocessed_state_updates.ts
@@ -1,0 +1,25 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.createTable('preprocessed_state_updates', (table) => {
+    table.integer('state_update_id').primary()
+    table.string('state_transition_hash').notNullable()
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.dropTable('preprocessed_state_updates')
+}

--- a/packages/backend/src/peripherals/database/shared/BaseRepository.ts
+++ b/packages/backend/src/peripherals/database/shared/BaseRepository.ts
@@ -1,3 +1,5 @@
+import { Knex } from 'knex'
+
 import { Logger } from '../../../tools/Logger'
 import { Database } from './Database'
 
@@ -27,8 +29,8 @@ export class BaseRepository {
     this.logger = logger.for(this)
   }
 
-  protected knex() {
-    return this.database.getKnex()
+  protected knex(trx?: Knex.Transaction) {
+    return this.database.getKnex(trx)
   }
 
   protected wrapAny<A extends unknown[], R>(

--- a/packages/backend/src/peripherals/database/shared/BaseRepository.ts
+++ b/packages/backend/src/peripherals/database/shared/BaseRepository.ts
@@ -33,6 +33,13 @@ export class BaseRepository {
     return this.database.getKnex(trx)
   }
 
+  async runInTransaction(
+    fun: (trx: Knex.Transaction) => Promise<void>
+  ): Promise<void> {
+    const knex = await this.knex()
+    await knex.transaction(fun)
+  }
+
   protected wrapAny<A extends unknown[], R>(
     method: AnyMethod<A, R>
   ): AnyMethod<A, R> {

--- a/packages/backend/src/peripherals/database/shared/Database.ts
+++ b/packages/backend/src/peripherals/database/shared/Database.ts
@@ -34,11 +34,11 @@ export class Database {
     })
   }
 
-  async getKnex() {
+  async getKnex(trx?: Knex.Transaction) {
     if (!this.migrated) {
       await this.migrationsComplete
     }
-    return this.knex
+    return trx ?? this.knex
   }
 
   getStatus() {

--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -186,6 +186,11 @@ declare module 'knex/types/tables' {
     state_update_id: number
   }
 
+  interface PreprocessedStateUpdateRow {
+    state_update_id: number
+    state_transition_hash: string
+  }
+
   interface Tables {
     key_values: KeyValueRow
     verifier_events: VerifierEventRow
@@ -208,6 +213,7 @@ declare module 'knex/types/tables' {
     sent_transactions: SentTransactionRow
     user_transactions: UserTransactionRow
     included_forced_requests: IncludedForcedRequestRow
+    preprocessed_state_updates: PreprocessedStateUpdateRow
   }
 }
 


### PR DESCRIPTION
Fully tested implementation of Preprocessor syncing logic. It doesn't contain any data processing yet, just the logic for (re)syncing up to the current state update. It correctly handles reorgs by rolling back preprocessing and catching up again.