### PR TITLE
Correctly fetch last fully synced state update id

### DIFF
--- a/packages/backend/src/core/preprocessing/Preprocessor.test.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.test.ts
@@ -58,13 +58,46 @@ describe(Preprocessor.name, () => {
     })
   })
 
+  describe(Preprocessor.prototype.getLastSyncedStateUpdate.name, () => {
+    it('handles sync status returning undefined', async () => {
+      const syncStatusRepo = mock<SyncStatusRepository>({
+        getLastSynced: async () => undefined,
+      })
+      const preprocessor = new Preprocessor(
+        mock<PreprocessedStateUpdateRepository>(),
+        syncStatusRepo,
+        mock<StateUpdateRepository>(),
+        Logger.SILENT
+      )
+      expect(await preprocessor.getLastSyncedStateUpdate()).toEqual(undefined)
+    })
+
+    it('calls state update repository for correct block', async () => {
+      const fakeStateUpdate = generateFakeStateUpdate(3)
+      const syncStatusRepo = mock<SyncStatusRepository>({
+        getLastSynced: async () => fakeStateUpdate.blockNumber,
+      })
+      const stateUpdateRepo = mock<StateUpdateRepository>({
+        findLastUntilBlockNumber: async () => fakeStateUpdate,
+      })
+      const preprocessor = new Preprocessor(
+        mock<PreprocessedStateUpdateRepository>(),
+        syncStatusRepo,
+        stateUpdateRepo,
+        Logger.SILENT
+      )
+      const lastStateUpdate = await preprocessor.getLastSyncedStateUpdate()
+      expect(lastStateUpdate).toEqual(fakeStateUpdate)
+      expect(stateUpdateRepo.findLastUntilBlockNumber).toHaveBeenCalledWith([
+        fakeStateUpdate.blockNumber,
+      ])
+    })
+  })
+
   describe(Preprocessor.prototype.calculateRequiredSyncDirection.name, () => {
     it('returns not-needed when everything is empty', async () => {
       const syncStatusRepo = mock<SyncStatusRepository>({
         getLastSynced: async () => undefined,
-      })
-      const stateUpdateRepo = mock<StateUpdateRepository>({
-        findLast: async () => undefined,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => undefined,
@@ -72,7 +105,7 @@ describe(Preprocessor.name, () => {
       const preprocessor = new Preprocessor(
         preprocessedRepo,
         syncStatusRepo,
-        stateUpdateRepo,
+        mock<StateUpdateRepository>(),
         Logger.SILENT
       )
       expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
@@ -84,9 +117,6 @@ describe(Preprocessor.name, () => {
       const syncStatusRepo = mock<SyncStatusRepository>({
         getLastSynced: async () => undefined,
       })
-      const stateUpdateRepo = mock<StateUpdateRepository>({
-        findLast: async () => undefined,
-      })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({
           stateUpdateId: 3,
@@ -96,7 +126,7 @@ describe(Preprocessor.name, () => {
       const preprocessor = new Preprocessor(
         preprocessedRepo,
         syncStatusRepo,
-        stateUpdateRepo,
+        mock<StateUpdateRepository>(),
         Logger.SILENT
       )
       expect(await preprocessor.calculateRequiredSyncDirection()).toEqual(
@@ -107,10 +137,10 @@ describe(Preprocessor.name, () => {
     it('returns forward when there are state updates but preprocessing has no entries', async () => {
       const fakeStateUpdate = generateFakeStateUpdate(3)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate.id,
+        getLastSynced: async () => fakeStateUpdate.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
-        findLast: async () => fakeStateUpdate,
+        findLastUntilBlockNumber: async () => fakeStateUpdate,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => undefined,
@@ -129,10 +159,10 @@ describe(Preprocessor.name, () => {
     it('returns backward when state update id is before preprocessing', async () => {
       const fakeStateUpdate = generateFakeStateUpdate(2)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate.id,
+        getLastSynced: async () => fakeStateUpdate.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
-        findLast: async () => fakeStateUpdate,
+        findLastUntilBlockNumber: async () => fakeStateUpdate,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({
@@ -154,11 +184,11 @@ describe(Preprocessor.name, () => {
     it("throws when the are more state updates but can't find preprocessed id", async () => {
       const fakeStateUpdate = generateFakeStateUpdate(10)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate.id,
+        getLastSynced: async () => fakeStateUpdate.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
         findById: async () => undefined,
-        findLast: async () => fakeStateUpdate,
+        findLastUntilBlockNumber: async () => fakeStateUpdate,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({
@@ -180,11 +210,11 @@ describe(Preprocessor.name, () => {
     it('returns not-needed when last state update ids and transition hashes match', async () => {
       const fakeStateUpdate = generateFakeStateUpdate(10)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate.id,
+        getLastSynced: async () => fakeStateUpdate.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
         findById: async (id: number) => ({ [10]: fakeStateUpdate }[id]),
-        findLast: async () => fakeStateUpdate,
+        findLastUntilBlockNumber: async () => fakeStateUpdate,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({
@@ -207,11 +237,11 @@ describe(Preprocessor.name, () => {
     it('returns backward when last state update ids match but transition hash is mismatched', async () => {
       const fakeStateUpdate = generateFakeStateUpdate(10)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate.id,
+        getLastSynced: async () => fakeStateUpdate.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
         findById: async (id: number) => ({ [10]: fakeStateUpdate }[id]),
-        findLast: async () => fakeStateUpdate,
+        findLastUntilBlockNumber: async () => fakeStateUpdate,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({
@@ -235,11 +265,11 @@ describe(Preprocessor.name, () => {
       const fakeStateUpdate5 = generateFakeStateUpdate(5)
       const fakeStateUpdate10 = generateFakeStateUpdate(10)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate10.id,
+        getLastSynced: async () => fakeStateUpdate10.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
         findById: async (id: number) => ({ [5]: fakeStateUpdate5 }[id]),
-        findLast: async () => fakeStateUpdate10,
+        findLastUntilBlockNumber: async () => fakeStateUpdate10,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({
@@ -262,11 +292,11 @@ describe(Preprocessor.name, () => {
       const fakeStateUpdate5 = generateFakeStateUpdate(5)
       const fakeStateUpdate10 = generateFakeStateUpdate(10)
       const syncStatusRepo = mock<SyncStatusRepository>({
-        getLastSynced: async () => fakeStateUpdate10.id,
+        getLastSynced: async () => fakeStateUpdate10.blockNumber,
       })
       const stateUpdateRepo = mock<StateUpdateRepository>({
         findById: async (id: number) => ({ [5]: fakeStateUpdate5 }[id]),
-        findLast: async () => fakeStateUpdate10,
+        findLastUntilBlockNumber: async () => fakeStateUpdate10,
       })
       const preprocessedRepo = mock<PreprocessedStateUpdateRepository>({
         findLast: async () => ({

--- a/packages/backend/src/core/preprocessing/Preprocessor.ts
+++ b/packages/backend/src/core/preprocessing/Preprocessor.ts
@@ -1,5 +1,8 @@
 import { PreprocessedStateUpdateRepository } from '../../peripherals/database/PreprocessedStateUpdateRepository'
-import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
+import {
+  StateUpdateRecord,
+  StateUpdateRepository,
+} from '../../peripherals/database/StateUpdateRepository'
 import { SyncStatusRepository } from '../../peripherals/database/SyncStatusRepository'
 import { Logger } from '../../tools/Logger'
 
@@ -28,6 +31,16 @@ export class Preprocessor {
     } while (direction !== 'stop')
   }
 
+  async getLastSyncedStateUpdate(): Promise<StateUpdateRecord | undefined> {
+    const lastSyncedBlock = await this.syncStatusRepository.getLastSynced()
+    if (lastSyncedBlock === undefined) {
+      return
+    }
+    return await this.stateUpdateRepository.findLastUntilBlockNumber(
+      lastSyncedBlock
+    )
+  }
+
   // Preprocessor can move only one state-update forward or backward. This
   // function returns the required direction of the next move.
   //
@@ -39,14 +52,14 @@ export class Preprocessor {
   // function moves backward until it finds a "common" state update, with the
   // same id and state transition hash. Then it moves forward.
   async calculateRequiredSyncDirection(): Promise<SyncDirection> {
-    const lastStateUpdateId = await this.syncStatusRepository.getLastSynced()
+    const lastStateUpdate = await this.getLastSyncedStateUpdate()
     const lastProcessedStateUpdate =
       await this.preprocessedStateUpdateRepository.findLast()
 
     // 1. Handle simple cases of empty state updates and empty preprocessed
     // state updates.
 
-    if (lastStateUpdateId === undefined) {
+    if (lastStateUpdate === undefined) {
       return lastProcessedStateUpdate === undefined ? 'stop' : 'backward'
     }
     if (lastProcessedStateUpdate === undefined) {
@@ -56,7 +69,7 @@ export class Preprocessor {
     // 2. Move back when current id is behind or there's hash mismatch,
     // (due to reorg), or throw on missing state update.
 
-    if (lastStateUpdateId < lastProcessedStateUpdate.stateUpdateId) {
+    if (lastStateUpdate.id < lastProcessedStateUpdate.stateUpdateId) {
       return 'backward'
     }
 
@@ -77,7 +90,7 @@ export class Preprocessor {
 
     // 3. If all is ok and we're behind, move forward
 
-    if (lastStateUpdateId > lastProcessedStateUpdate.stateUpdateId) {
+    if (lastStateUpdate.id > lastProcessedStateUpdate.stateUpdateId) {
       return 'forward'
     }
 

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.test.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.test.ts
@@ -133,6 +133,48 @@ describe(StateUpdateRepository.name, () => {
     expect(last).toEqual(stateUpdate)
   })
 
+  it('gets last state update by id until given block number', async () => {
+    let last = await repository.findLastUntilBlockNumber(30_002)
+    expect(last).toEqual(undefined)
+
+    const stateUpdate1 = {
+      id: 30_001_000,
+      blockNumber: 30_001,
+      rootHash: PedersenHash.fake(),
+      stateTransitionHash: Hash256.fake(),
+      timestamp: Timestamp(0),
+    }
+    const stateUpdate2 = {
+      id: 30_002_000,
+      blockNumber: 30_002,
+      rootHash: PedersenHash.fake(),
+      stateTransitionHash: Hash256.fake(),
+      timestamp: Timestamp(0),
+    }
+    await repository.add({
+      stateUpdate: stateUpdate1,
+      positions: [],
+      prices: [],
+    })
+    await repository.add({
+      stateUpdate: stateUpdate2,
+      positions: [],
+      prices: [],
+    })
+
+    last = await repository.findLastUntilBlockNumber(30_000)
+    expect(last).toEqual(undefined)
+
+    last = await repository.findLastUntilBlockNumber(30_001)
+    expect(last).toEqual(stateUpdate1)
+
+    last = await repository.findLastUntilBlockNumber(30_002)
+    expect(last).toEqual(stateUpdate2)
+
+    last = await repository.findLastUntilBlockNumber(30_999)
+    expect(last).toEqual(stateUpdate2)
+  })
+
   it('find state update by id', async () => {
     let last = await repository.findById(30_002)
     expect(last).toEqual(undefined)

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -35,6 +35,7 @@ export class StateUpdateRepository extends BaseRepository {
 
     this.add = this.wrapAdd(this.add)
     this.findLast = this.wrapFind(this.findLast)
+    this.findLastUntilBlockNumber = this.wrapFind(this.findLastUntilBlockNumber)
     this.findById = this.wrapFind(this.findById)
     this.findIdByRootHash = this.wrapFind(this.findIdByRootHash)
     this.getAll = this.wrapGet(this.getAll)
@@ -84,6 +85,17 @@ export class StateUpdateRepository extends BaseRepository {
   async findLast(): Promise<StateUpdateRecord | undefined> {
     const knex = await this.knex()
     const row = await knex('state_updates').orderBy('id', 'desc').first()
+    return row && toStateUpdateRecord(row)
+  }
+
+  async findLastUntilBlockNumber(
+    blockNumber: number
+  ): Promise<StateUpdateRecord | undefined> {
+    const knex = await this.knex()
+    const row = await knex('state_updates')
+      .where('block_number', '<=', blockNumber)
+      .orderBy('id', 'desc')
+      .first()
     return row && toStateUpdateRecord(row)
   }
 


### PR DESCRIPTION
This change fixes my previous mistake where I thought that:

`SyncStatusRepository.getLastSynced()`

returns last synced *state update id*, while it actually returns last synced *block number*. So we need to make additional call to `StateUpdateRepository` for corresponding state update id.