### PR TITLE
Update asset registration to merge on conflict

### DIFF
--- a/packages/backend/src/peripherals/database/AssetRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AssetRepository.test.ts
@@ -27,6 +27,23 @@ describe(AssetRepository.name, () => {
     expect(actual).toEqual(record)
   })
 
+  it('merges single record on conflict', async () => {
+    const record: AssetDetails = dummyAsset('1', '2')
+    record.quantum = 11n
+
+    const recordUpdated: AssetDetails = {
+      ...record,
+      quantum: 22n,
+    }
+
+    await assetRepository.addManyDetails([record])
+    await assetRepository.addManyDetails([recordUpdated])
+    const actual = await assetRepository.findDetailsByAssetHash(
+      record.assetHash
+    )
+    expect(actual).toEqual(recordUpdated)
+  })
+
   it('adds multiple records and queries them', async () => {
     const records = [
       dummyAsset('10', '11'),
@@ -55,6 +72,23 @@ describe(AssetRepository.name, () => {
     )
 
     expect(actual).toEqual(record)
+  })
+
+  it('merges single record on conflict', async () => {
+    const record: AssetRegistrationRecord = dummyAssetRegistration('1')
+    record.quantum = 11n
+    const recordUpdated: AssetRegistrationRecord = {
+      ...record,
+      quantum: 22n,
+    }
+
+    await assetRepository.addManyRegistrations([record])
+    await assetRepository.addManyRegistrations([recordUpdated])
+
+    const actual = await assetRepository.findRegistrationByAssetTypeHash(
+      record.assetTypeHash
+    )
+    expect(actual).toEqual(recordUpdated)
   })
 
   it('adds multiple records and queries them', async () => {
@@ -119,7 +153,7 @@ export function dummyAssetRegistration(
   type = 'ERC20' as AssetType,
   name = undefined,
   symbol = undefined,
-  quantum = BigNumber.from(1).toBigInt(),
+  quantum = 1n,
   decimals = undefined,
   contractError = []
 ): AssetRegistrationRecord {

--- a/packages/backend/src/peripherals/database/AssetRepository.ts
+++ b/packages/backend/src/peripherals/database/AssetRepository.ts
@@ -39,6 +39,8 @@ export class AssetRepository extends BaseRepository {
     const rows = records.map(toAssetDetailsRow)
     const hashes = await knex('asset_details')
       .insert(rows)
+      .onConflict('asset_hash')
+      .merge()
       .returning('asset_hash')
     return hashes.map((x) => AssetHash(x.asset_hash))
   }
@@ -50,6 +52,8 @@ export class AssetRepository extends BaseRepository {
     const rows = record.map(toAssetRegistrationRow)
     const hashes = await knex('asset_registrations')
       .insert(rows)
+      .onConflict('asset_type_hash')
+      .merge()
       .returning('asset_type_hash')
     return hashes.map((x) => Hash256(x.asset_type_hash))
   }


### PR DESCRIPTION
When state update is halted half-way and backend is restarted, it restarts syncing from last synced block. But since some asset registrations have already gone to the DB in the previous, halted run, they cause unique constraint violation.

Even though I see merit in adding blockNumber and timestamp with proper rollback support for asset registrations, for now I opt for a quick solution of adding `onConflict().merge()` and revisiting it in the future.