### PR TITLE
Increase build speed 4x - parallel run, no clean on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     ]
   },
   "scripts": {
-    "format": "wsrun -ecsm format",
-    "format:fix": "wsrun -ecsm format:fix",
-    "lint": "wsrun -ecsm lint",
-    "lint:fix": "wsrun -ecsm lint:fix",
-    "typecheck": "wsrun -ecsm typecheck",
+    "format": "wsrun -em format",
+    "format:fix": "wsrun -em format:fix",
+    "lint": "wsrun -em lint",
+    "lint:fix": "wsrun -em lint:fix",
+    "typecheck": "wsrun -em typecheck",
     "test": "wsrun -ecsm test",
-    "build": "wsrun -ecsm build",
+    "build": "wsrun -etm build",
     "clean": "wsrun -ecsm clean",
     "start": "cd packages/backend && yarn start"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,7 +14,6 @@
     "lint": "eslint --ext .ts --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "tsc",
     "postbuild": "cp src/core/migrations/blockTimestamps.json build/core/migrations/blockTimestamps.json",
     "clean": "rm -rf build",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint --ext .ts --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "tsc",
     "clean": "rm -rf build",
     "test": "mocha"

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint --ext .ts --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "tsc",
     "clean": "rm -rf build",
     "test": "mocha"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,6 @@
     "lint": "eslint --ext .ts,.tsx --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "NODE_ENV=production gulp build",
     "clean": "rm -rf build",
     "test": "mocha",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint --ext .ts --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "tsc",
     "clean": "rm -rf build",
     "test": "mocha"

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint --ext .ts --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "tsc",
     "clean": "rm -rf build",
     "test": "mocha"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint --ext .ts --max-warnings 0 src",
     "lint:fix": "yarn lint --fix",
     "typecheck": "tsc --noEmit",
-    "prebuild": "yarn clean",
     "build": "tsc",
     "clean": "rm -rf build",
     "test": "mocha"


### PR DESCRIPTION
Removing `"prebuild": yarn clean` is crucial as it allows typescript's `incrementalBuild` to work.