### PR TITLE
Init state tree when application starts

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -192,7 +192,10 @@ export class Application {
     )
 
     let syncService
-    let stateUpdater
+    let stateUpdater:
+      | SpotValidiumUpdater
+      | PerpetualValidiumUpdater
+      | PerpetualRollupUpdater
 
     if (config.starkex.dataAvailabilityMode === 'validium') {
       const availabilityGatewayClient = new AvailabilityGatewayClient(
@@ -562,6 +565,7 @@ export class Application {
       await ethereumClient.assertChainId(config.starkex.blockchain.chainId)
 
       await userTransactionMigrator.migrate()
+      await stateUpdater.initTree()
 
       if (config.enableSync) {
         transactionStatusService.start()

--- a/packages/backend/src/core/PerpetualRollupUpdater.ts
+++ b/packages/backend/src/core/PerpetualRollupUpdater.ts
@@ -43,6 +43,11 @@ export class PerpetualRollupUpdater extends StateUpdater<PositionLeaf> {
     )
   }
 
+  async initTree() {
+    const { oldHash } = await this.readLastUpdate()
+    await this.ensureStateTree(oldHash, positionTreeHeight)
+  }
+
   async loadRequiredPages(
     stateTransitions: Omit<StateTransitionRecord, 'id'>[]
   ): Promise<(StateTransitionRecord & { pages: string[] })[]> {

--- a/packages/backend/src/core/PerpetualValidiumUpdater.ts
+++ b/packages/backend/src/core/PerpetualValidiumUpdater.ts
@@ -44,6 +44,11 @@ export class PerpetualValidiumUpdater extends StateUpdater<PositionLeaf> {
     )
   }
 
+  async initTree() {
+    const { oldHash } = await this.readLastUpdate()
+    await this.ensureStateTree(oldHash, positionTreeHeight)
+  }
+
   async processValidiumStateTransition(
     transition: ValidiumStateTransition,
     perpetualCairoOutput: PerpetualCairoOutput,

--- a/packages/backend/src/core/SpotValidiumUpdater.ts
+++ b/packages/backend/src/core/SpotValidiumUpdater.ts
@@ -44,6 +44,11 @@ export class SpotValidiumUpdater extends StateUpdater<VaultLeaf> {
     )
   }
 
+  async initTree() {
+    const { oldHash } = await this.readLastUpdate()
+    await this.ensureStateTree(oldHash, vaultTreeHeight)
+  }
+
   async processSpotValidiumStateTransition(
     transition: ValidiumStateTransition,
     spotCairoOutput: SpotCairoOutput,


### PR DESCRIPTION
This is needed for merkle proofs to work even when not syncing.