### PR TITLE
Use stringAs in FrontendRouter

### DIFF
--- a/packages/backend/src/api/routers/FrontendRouter.ts
+++ b/packages/backend/src/api/routers/FrontendRouter.ts
@@ -1,4 +1,5 @@
 import {
+  stringAs,
   stringAsBigInt,
   stringAsPositiveInt,
   TradingMode,
@@ -173,14 +174,14 @@ export function createFrontendRouter(
     withTypedContext(
       z.object({
         params: z.object({
-          starkKey: z.string(),
+          starkKey: stringAs(StarkKey),
         }),
       }),
       async (ctx) => {
         const givenUser = getGivenUser(ctx)
         const result = await userController.getUserPage(
           givenUser,
-          StarkKey(ctx.params.starkKey)
+          ctx.params.starkKey
         )
         applyControllerResult(ctx, result)
       }
@@ -192,7 +193,7 @@ export function createFrontendRouter(
     withTypedContext(
       z.object({
         params: z.object({
-          starkKey: z.string(),
+          starkKey: stringAs(StarkKey),
         }),
         query: z.object({
           page: z.optional(stringAsPositiveInt()),
@@ -204,7 +205,7 @@ export function createFrontendRouter(
         const pagination = getPagination(ctx.query)
         const result = await userController.getUserAssetsPage(
           givenUser,
-          StarkKey(ctx.params.starkKey),
+          ctx.params.starkKey,
           pagination
         )
         applyControllerResult(ctx, result)
@@ -217,7 +218,7 @@ export function createFrontendRouter(
     withTypedContext(
       z.object({
         params: z.object({
-          starkKey: z.string(),
+          starkKey: stringAs(StarkKey),
         }),
         query: z.object({
           page: z.optional(stringAsPositiveInt()),
@@ -229,7 +230,7 @@ export function createFrontendRouter(
         const pagination = getPagination(ctx.query)
         const result = await userController.getUserBalanceChangesPage(
           givenUser,
-          StarkKey(ctx.params.starkKey),
+          ctx.params.starkKey,
           pagination
         )
         applyControllerResult(ctx, result)
@@ -267,14 +268,14 @@ export function createFrontendRouter(
     withTypedContext(
       z.object({
         params: z.object({
-          transactionHash: z.string(),
+          transactionHash: stringAs(Hash256),
         }),
       }),
       async (ctx) => {
         const givenUser = getGivenUser(ctx)
         const result = await transactionController.getTransactionPage(
           givenUser,
-          Hash256(ctx.params.transactionHash)
+          ctx.params.transactionHash
         )
         applyControllerResult(ctx, result)
       }

--- a/packages/backend/src/api/routers/utils.ts
+++ b/packages/backend/src/api/routers/utils.ts
@@ -1,4 +1,4 @@
-import { UserDetails } from '@explorer/shared'
+import { assertUnreachable, UserDetails } from '@explorer/shared'
 import { EthereumAddress, StarkKey } from '@explorer/types'
 import { Context } from 'koa'
 
@@ -6,21 +6,26 @@ import { PaginationOptions } from '../../model/PaginationOptions'
 import { ControllerResult } from '../controllers/ControllerResult'
 
 export function applyControllerResult(ctx: Context, result: ControllerResult) {
-  if (result.type === 'redirect') {
-    ctx.redirect(result.url)
-  } else {
-    if (result.type === 'success') {
+  switch (result.type) {
+    case 'redirect':
+      ctx.redirect(result.url)
+      return
+    case 'success':
       ctx.status = 200
-    } else if (result.type === 'created') {
+      break
+    case 'created':
       ctx.status = 201
-    } else if (result.type === 'bad request') {
+      break
+    case 'bad request':
       ctx.status = 400
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    } else if (result.type === 'not found') {
+      break
+    case 'not found':
       ctx.status = 404
-    }
-    ctx.body = result.content
+      break
+    default:
+      assertUnreachable(result)
   }
+  ctx.body = result.content
 }
 
 export function getGivenUser(ctx: Context): Partial<UserDetails> {

--- a/packages/backend/src/api/routers/utils.ts
+++ b/packages/backend/src/api/routers/utils.ts
@@ -1,8 +1,9 @@
-import { assertUnreachable, UserDetails } from '@explorer/shared'
+import { UserDetails } from '@explorer/shared'
 import { EthereumAddress, StarkKey } from '@explorer/types'
 import { Context } from 'koa'
 
 import { PaginationOptions } from '../../model/PaginationOptions'
+import { assertUnreachable } from '../../utils/assertUnreachable'
 import { ControllerResult } from '../controllers/ControllerResult'
 
 export function applyControllerResult(ctx: Context, result: ControllerResult) {


### PR DESCRIPTION
Instead of using z.string() and then converting this string to Hash256, we can use stringAs(Hash256). It provides better error message (not internal server error at least).