### PR TITLE
Do not highlight unclickable table rows

### DIFF
--- a/packages/frontend/src/view/components/table/TableRow.tsx
+++ b/packages/frontend/src/view/components/table/TableRow.tsx
@@ -24,13 +24,13 @@ export function TableRow(props: TableRowProps) {
           <td
             key={col}
             className={cx(
-              'group-hover:bg-gray-800 group-hover:bg-opacity-40',
               !props.link && 'px-2 sm:px-2.5',
               !props.link && col === 0 && 'pl-4 sm:pl-5',
               !props.link && col === props.cells.length - 1 && 'pr-4 sm:pr-5',
               (numeric || monospace) && 'font-mono',
               numeric && 'text-right',
-              props.link && 'cursor-pointer',
+              props.link &&
+                'cursor-pointer group-hover:bg-gray-800 group-hover:bg-opacity-40',
               !props.link && className
             )}
           >


### PR DESCRIPTION
This PR fixes a misleading UX that was highlighting unclickable table rows on hover 