### PR TITLE
Open port early (due to heroku check)

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -622,6 +622,7 @@ export class Application {
     this.start = async () => {
       logger.for(this).info('Starting')
 
+      await apiServer.listen()
       if (config.freshStart) await database.rollbackAll()
       await database.migrateToLatest()
 
@@ -631,7 +632,6 @@ export class Application {
       await withdrawableAssetMigrator.migrate()
       await stateUpdater.initTree()
 
-      await apiServer.listen()
       if (config.enableSync) {
         transactionStatusService.start()
         await syncScheduler.start()


### PR DESCRIPTION
Heroku stops the process if port is not open after some period of time - and during preprocessing this time can be significant.

Moving apiServer.listen() back where it was.