### PR TITLE
Accept time_created and unknown fields in live l2 tx schema

### DIFF
--- a/packages/backend/src/peripherals/starkware/schema/PerpetualLiveL2TransactionResponse.ts
+++ b/packages/backend/src/peripherals/starkware/schema/PerpetualLiveL2TransactionResponse.ts
@@ -2,23 +2,24 @@ import { z } from 'zod'
 
 import { PerpetualL2Transaction } from './PerpetualBatchInfoResponse'
 
-const PerpetualLiveL2TransactionResponseTransactionInfo = z.strictObject({
+const PerpetualLiveL2TransactionResponseTransactionInfo = z.object({
   tx: PerpetualL2Transaction,
   tx_id: z.number(),
 })
-const PerpetualLiveL2TransactionResponseTransaction = z.strictObject({
+const PerpetualLiveL2TransactionResponseTransaction = z.object({
   apex_id: z.number(),
   tx_info: z
     .string()
     .transform((s) =>
       PerpetualLiveL2TransactionResponseTransactionInfo.parse(JSON.parse(s))
     ),
+  time_created: z.number().optional(), // Temporarily optional, only on goerli API
 })
 
 export type PerpetualLiveL2TransactionResponse = z.infer<
   typeof PerpetualLiveL2TransactionResponse
 >
-export const PerpetualLiveL2TransactionResponse = z.strictObject({
+export const PerpetualLiveL2TransactionResponse = z.object({
   count: z.number(),
   txs: z.array(PerpetualLiveL2TransactionResponseTransaction),
 })

--- a/packages/backend/src/test/starkwareData.ts
+++ b/packages/backend/src/test/starkwareData.ts
@@ -344,5 +344,6 @@ export const EXAMPLE_PERPETUAL_TRANSACTIONS = {
       tx: transaction,
       tx_id: 4000 + index,
     }),
+    time_created: 1681458071 + index,
   })),
 }


### PR DESCRIPTION
Tx schema no longer is *strict*, which means that it ignores fields it doesn't recognize, instead of throwing an error.

Adding strictness is actually counter-productive in network messages. For example we requested to have a new field added (timestamp) and once it appeared in response, things started failing everywhere, because we haven't updated schema for it. 

We don't want to fail if a new field is added to the message response. 