### PR TITLE
Rename tx type EscapeVerified to VerifyEscape

### DIFF
--- a/packages/backend/src/api/controllers/HomeController.ts
+++ b/packages/backend/src/api/controllers/HomeController.ts
@@ -25,7 +25,7 @@ const FORCED_TRANSACTION_TYPES: UserTransactionData['type'][] = [
   'ForcedWithdrawal',
   'ForcedTrade',
   'FullWithdrawal',
-  'EscapeVerified',
+  'VerifyEscape',
   'FinalizeEscape',
 ]
 //TODO: Do we want FreezeRequest here?

--- a/packages/backend/src/api/controllers/StateUpdateController.ts
+++ b/packages/backend/src/api/controllers/StateUpdateController.ts
@@ -31,7 +31,7 @@ const FORCED_TRANSACTION_TYPES: UserTransactionData['type'][] = [
   'ForcedWithdrawal',
   'ForcedTrade',
   'FullWithdrawal',
-  // 'EscapeVerified' - not needed. When frozen, there are no state updates.
+  // 'VerifyEscape' - not needed. When frozen, there are no state updates.
 ]
 
 export class StateUpdateController {

--- a/packages/backend/src/api/controllers/TransactionController.ts
+++ b/packages/backend/src/api/controllers/TransactionController.ts
@@ -229,7 +229,7 @@ export class TransactionController {
         return { type: 'success', content }
       }
 
-      case 'EscapeVerified': {
+      case 'VerifyEscape': {
         //TODO: Check if we need different for Spot and Perpetual
         if (context.tradingMode !== 'perpetual') {
           return { type: 'not found' }
@@ -441,7 +441,7 @@ export class TransactionController {
         return { type: 'success', content }
       }
 
-      case 'EscapeVerified': {
+      case 'VerifyEscape': {
         //TODO: Check if we need different for Spot and Perpetual
         if (context.tradingMode !== 'perpetual') {
           return { type: 'not found' }

--- a/packages/backend/src/api/controllers/TransactionSubmitController.test.ts
+++ b/packages/backend/src/api/controllers/TransactionSubmitController.test.ts
@@ -516,7 +516,7 @@ describe(TransactionSubmitController.name, () => {
   })
 
   describe(
-    TransactionSubmitController.prototype.submitEscapeVerified.name,
+    TransactionSubmitController.prototype.submitVerifyEscape.name,
     () => {
       it('handles nonexistent transaction', async () => {
         const controller = new TransactionSubmitController(
@@ -534,7 +534,7 @@ describe(TransactionSubmitController.name, () => {
         )
 
         const hash = Hash256.fake()
-        const result = await controller.submitEscapeVerified(
+        const result = await controller.submitVerifyEscape(
           hash,
           StarkKey.fake(),
           123n
@@ -564,7 +564,7 @@ describe(TransactionSubmitController.name, () => {
         )
 
         const hash = Hash256.fake()
-        const result = await controller.submitEscapeVerified(
+        const result = await controller.submitVerifyEscape(
           hash,
           StarkKey.fake(),
           123n
@@ -595,7 +595,7 @@ describe(TransactionSubmitController.name, () => {
         )
 
         const hash = Hash256.fake()
-        const result = await controller.submitEscapeVerified(
+        const result = await controller.submitVerifyEscape(
           hash,
           StarkKey.fake(),
           123n
@@ -636,7 +636,7 @@ describe(TransactionSubmitController.name, () => {
           fakeCollateralAsset
         )
 
-        const result = await controller.submitEscapeVerified(
+        const result = await controller.submitVerifyEscape(
           hash,
           StarkKey.fake(),
           123n

--- a/packages/backend/src/api/controllers/TransactionSubmitController.ts
+++ b/packages/backend/src/api/controllers/TransactionSubmitController.ts
@@ -211,7 +211,7 @@ export class TransactionSubmitController {
     return { type: 'created', content: { id: transactionHash } }
   }
 
-  async submitEscapeVerified(
+  async submitVerifyEscape(
     transactionHash: Hash256,
     starkKey: StarkKey,
     positionOrVaultId: bigint
@@ -230,7 +230,7 @@ export class TransactionSubmitController {
       transactionHash,
       timestamp,
       data: {
-        type: 'EscapeVerified',
+        type: 'VerifyEscape',
         starkKey,
         positionOrVaultId,
       },

--- a/packages/backend/src/api/controllers/getEscapableAssets.ts
+++ b/packages/backend/src/api/controllers/getEscapableAssets.ts
@@ -25,7 +25,7 @@ export async function getEscapableAssets(
     return { finalizable: [], allCount: 0 }
   }
   const allEscapeVerifiedTransactions =
-    await userTransactionRepository.getByStarkKey(starkKey, ['EscapeVerified'])
+    await userTransactionRepository.getByStarkKey(starkKey, ['VerifyEscape'])
 
   if (allEscapeVerifiedTransactions.length === 0) {
     return { finalizable: [], allCount: 0 }

--- a/packages/backend/src/api/controllers/sentTransactionToEntry.ts
+++ b/packages/backend/src/api/controllers/sentTransactionToEntry.ts
@@ -17,7 +17,7 @@ export function extractSentTxEntryType(
     case 'Withdraw':
     case 'WithdrawWithTokenId':
       return 'WITHDRAW'
-    case 'EscapeVerified':
+    case 'VerifyEscape':
       return 'INITIATE_ESCAPE'
     case 'FreezeRequest':
       return 'FREEZE_REQUEST'
@@ -39,7 +39,7 @@ export function extractSentTxAmount(
       return data.syntheticAmount
     case 'Withdraw':
     case 'WithdrawWithTokenId':
-    case 'EscapeVerified':
+    case 'VerifyEscape':
     case 'FreezeRequest':
       return undefined
     default:
@@ -77,7 +77,7 @@ export function extractSentTxAsset(
         details: assetDetails,
       }
     }
-    case 'EscapeVerified': {
+    case 'VerifyEscape': {
       return collateralAsset ? { hashOrId: collateralAsset.assetId } : undefined
     }
     case 'FreezeRequest':

--- a/packages/backend/src/api/controllers/userTransactionToEntry.ts
+++ b/packages/backend/src/api/controllers/userTransactionToEntry.ts
@@ -17,7 +17,7 @@ function extractUserTxAmount(
       return data.syntheticAmount
     case 'FullWithdrawal':
       return undefined
-    case 'EscapeVerified':
+    case 'VerifyEscape':
       return data.withdrawalAmount
     case 'Withdraw':
     case 'WithdrawWithTokenId':
@@ -36,7 +36,7 @@ function extractUserTxAsset(
   switch (data.type) {
     case 'ForcedWithdrawal':
     case 'FinalizeEscape':
-    case 'EscapeVerified':
+    case 'VerifyEscape':
       return collateralAsset ? { hashOrId: collateralAsset.assetId } : undefined
     case 'ForcedTrade':
       return { hashOrId: data.syntheticAssetId }
@@ -67,7 +67,7 @@ function extractUserTxEntryType(
     case 'ForcedWithdrawal':
     case 'FullWithdrawal':
       return 'FORCED_WITHDRAW'
-    case 'EscapeVerified':
+    case 'VerifyEscape':
       return 'INITIATE_ESCAPE'
     case 'Withdraw':
     case 'WithdrawWithTokenId':

--- a/packages/backend/src/api/routers/ForcedTransactionRouter.ts
+++ b/packages/backend/src/api/routers/ForcedTransactionRouter.ts
@@ -220,7 +220,7 @@ export function createTransactionRouter(
         }),
       }),
       async (ctx) => {
-        const result = await transactionSubmitController.submitEscapeVerified(
+        const result = await transactionSubmitController.submitVerifyEscape(
           ctx.request.body.hash,
           ctx.request.body.starkKey,
           ctx.request.body.positionOrVaultId

--- a/packages/backend/src/core/AssetDetailsService.test.ts
+++ b/packages/backend/src/core/AssetDetailsService.test.ts
@@ -195,7 +195,7 @@ describe(AssetDetailsService.name, () => {
       })
       it('should return undefined for EscapeVerified', () => {
         const result = assetDetailsService.getUserTransactionAssetHash(
-          userTransaction({ type: 'EscapeVerified' } as UserTransactionData)
+          userTransaction({ type: 'VerifyEscape' } as UserTransactionData)
         )
         expect(result).toEqual(undefined)
       })

--- a/packages/backend/src/core/AssetDetailsService.ts
+++ b/packages/backend/src/core/AssetDetailsService.ts
@@ -80,7 +80,7 @@ export class AssetDetailsService {
       case 'ForcedTrade':
       case 'ForcedWithdrawal':
       case 'FullWithdrawal':
-      case 'EscapeVerified':
+      case 'VerifyEscape':
         return undefined
       default:
         assertUnreachable(userTransaction.data)

--- a/packages/backend/src/core/collectors/UserTransactionCollector.test.ts
+++ b/packages/backend/src/core/collectors/UserTransactionCollector.test.ts
@@ -495,7 +495,7 @@ describe(UserTransactionCollector.name, () => {
       transactionHash,
       timestamp: Timestamp(1234000),
       data: {
-        type: 'EscapeVerified',
+        type: 'VerifyEscape',
         starkKey,
         positionId,
         sharedStateHash,

--- a/packages/backend/src/core/collectors/UserTransactionCollector.ts
+++ b/packages/backend/src/core/collectors/UserTransactionCollector.ts
@@ -177,7 +177,7 @@ export class UserTransactionCollector {
         return this.userTransactionRepository.add({
           ...base,
           data: {
-            type: 'EscapeVerified',
+            type: 'VerifyEscape',
             starkKey: StarkKey.from(event.args.starkKey),
             withdrawalAmount: event.args.withdrawalAmount.toBigInt(),
             positionId: event.args.positionId.toBigInt(),

--- a/packages/backend/src/peripherals/database/transactions/SentTransaction.test.ts
+++ b/packages/backend/src/peripherals/database/transactions/SentTransaction.test.ts
@@ -4,10 +4,10 @@ import { expect } from 'earl'
 import {
   decodeSentTransactionData,
   encodeSentTransactionData,
-  EscapeVerifiedData,
   ForcedTradeData,
   ForcedWithdrawalData,
   FreezeRequestData,
+  VerifyEscapeData,
   WithdrawData,
 } from './SentTransaction'
 
@@ -84,8 +84,8 @@ describe(encodeSentTransactionData.name, () => {
   })
 
   it('can encode and decode a VerifyEscape', () => {
-    const data: EscapeVerifiedData = {
-      type: 'EscapeVerified',
+    const data: VerifyEscapeData = {
+      type: 'VerifyEscape',
       starkKey: StarkKey.fake(),
       positionOrVaultId: 1234n,
     }

--- a/packages/backend/src/peripherals/database/transactions/SentTransaction.ts
+++ b/packages/backend/src/peripherals/database/transactions/SentTransaction.ts
@@ -15,7 +15,7 @@ export type SentTransactionData =
   | WithdrawData
   | WithdrawWithTokenIdData
   | FreezeRequestData
-  | EscapeVerifiedData
+  | VerifyEscapeData
   | FinalizeEscapeData
 
 export type SentTransactionJSON = ToJSON<SentTransactionData>
@@ -66,8 +66,8 @@ export interface FreezeRequestData {
   quantizedAmount: bigint
 }
 
-export interface EscapeVerifiedData {
-  type: 'EscapeVerified'
+export interface VerifyEscapeData {
+  type: 'VerifyEscape'
   starkKey: StarkKey
   positionOrVaultId: bigint
 }
@@ -93,8 +93,8 @@ export function encodeSentTransactionData(
       return encodeWithdrawWithTokenId(values)
     case 'FreezeRequest':
       return encodeFreezeRequest(values)
-    case 'EscapeVerified':
-      return encodeEscapeVerified(values)
+    case 'VerifyEscape':
+      return encodeVerifyEscape(values)
     case 'FinalizeEscape':
       return encodeFinalizeEscape(values)
     default:
@@ -116,8 +116,8 @@ export function decodeSentTransactionData(
       return decodeWithdrawWithTokenId(values)
     case 'FreezeRequest':
       return decodeFreezeRequest(values)
-    case 'EscapeVerified':
-      return decodeEscapeVerified(values)
+    case 'VerifyEscape':
+      return decodeVerifyEscape(values)
     case 'FinalizeEscape':
       return decodeFinalizeEscape(values)
     default:
@@ -235,23 +235,23 @@ function decodeWithdrawWithTokenId(
   }
 }
 
-function encodeEscapeVerified(
-  values: EscapeVerifiedData
-): Encoded<EscapeVerifiedData> {
+function encodeVerifyEscape(
+  values: VerifyEscapeData
+): Encoded<VerifyEscapeData> {
   return {
     starkKey: values.starkKey,
     vaultOrPositionId: values.positionOrVaultId,
     data: {
-      type: 'EscapeVerified',
+      type: 'VerifyEscape',
       starkKey: values.starkKey.toString(),
       positionOrVaultId: values.positionOrVaultId.toString(),
     },
   }
 }
 
-function decodeEscapeVerified(
-  values: ToJSON<EscapeVerifiedData>
-): EscapeVerifiedData {
+function decodeVerifyEscape(
+  values: ToJSON<VerifyEscapeData>
+): VerifyEscapeData {
   return {
     ...values,
     starkKey: StarkKey(values.starkKey),

--- a/packages/backend/src/peripherals/database/transactions/UserTransaction.test.ts
+++ b/packages/backend/src/peripherals/database/transactions/UserTransaction.test.ts
@@ -10,11 +10,11 @@ import { expect } from 'earl'
 import {
   decodeUserTransactionData,
   encodeUserTransactionData,
-  EscapeVerifiedData,
   ForcedTradeData,
   ForcedWithdrawalData,
   FullWithdrawalData,
   MintWithdrawData,
+  VerifyEscapeData,
   WithdrawData,
   WithdrawWithTokenIdData,
 } from './UserTransaction'
@@ -173,9 +173,9 @@ describe(encodeUserTransactionData.name, () => {
     expect(decoded).toEqual(data)
   })
 
-  it('can encode a EscapeVerified', () => {
-    const data: EscapeVerifiedData = {
-      type: 'EscapeVerified',
+  it('can encode a VerifyEscape', () => {
+    const data: VerifyEscapeData = {
+      type: 'VerifyEscape',
       starkKey: StarkKey.fake(),
       withdrawalAmount: 1234n,
       sharedStateHash: Hash256.fake(),
@@ -187,7 +187,7 @@ describe(encodeUserTransactionData.name, () => {
       starkKeyA: data.starkKey,
       vaultOrPositionIdA: data.positionId,
       data: {
-        type: 'EscapeVerified',
+        type: 'VerifyEscape',
         starkKey: data.starkKey.toString(),
         positionId: '5678',
         withdrawalAmount: data.withdrawalAmount.toString(),

--- a/packages/backend/src/peripherals/database/transactions/UserTransaction.ts
+++ b/packages/backend/src/peripherals/database/transactions/UserTransaction.ts
@@ -22,7 +22,7 @@ export type UserTransactionData =
   | ForcedWithdrawalData
   | FullWithdrawalData
   | WithdrawalPerformedData
-  | EscapeVerifiedData
+  | VerifyEscapeData
   | FinalizeEscapeData
 
 export type WithdrawalPerformedData =
@@ -61,8 +61,8 @@ export interface ForcedTradeData {
   nonce: bigint
 }
 
-export interface EscapeVerifiedData {
-  type: 'EscapeVerified'
+export interface VerifyEscapeData {
+  type: 'VerifyEscape'
   starkKey: StarkKey
   withdrawalAmount: bigint
   sharedStateHash: Hash256
@@ -116,8 +116,8 @@ export function encodeUserTransactionData(
       return encodeFullWithdrawal(values)
     case 'ForcedTrade':
       return encodeForcedTrade(values)
-    case 'EscapeVerified':
-      return encodeEscapeVerified(values)
+    case 'VerifyEscape':
+      return encodeVerifyEscape(values)
     case 'Withdraw':
       return encodeWithdraw(values)
     case 'WithdrawWithTokenId':
@@ -141,8 +141,8 @@ export function decodeUserTransactionData(
       return decodeFullWithdrawal(values)
     case 'ForcedTrade':
       return decodeForcedTrade(values)
-    case 'EscapeVerified':
-      return decodeEscapeVerified(values)
+    case 'VerifyEscape':
+      return decodeVerifyEscape(values)
     case 'Withdraw':
       return decodeWithdraw(values)
     case 'WithdrawWithTokenId':
@@ -206,9 +206,9 @@ function decodeFullWithdrawal(
   }
 }
 
-function encodeEscapeVerified(
-  values: EscapeVerifiedData
-): Encoded<EscapeVerifiedData> {
+function encodeVerifyEscape(
+  values: VerifyEscapeData
+): Encoded<VerifyEscapeData> {
   return {
     starkKeyA: values.starkKey,
     vaultOrPositionIdA: values.positionId,
@@ -222,9 +222,9 @@ function encodeEscapeVerified(
   }
 }
 
-function decodeEscapeVerified(
-  values: ToJSON<EscapeVerifiedData>
-): EscapeVerifiedData {
+function decodeVerifyEscape(
+  values: ToJSON<VerifyEscapeData>
+): VerifyEscapeData {
   return {
     ...values,
     starkKey: StarkKey(values.starkKey),


### PR DESCRIPTION
This is for consistency of naming with other transaction types, e.g. FinalizeEscape. See UserTransaction.ts