### PR TITLE
Collect from Feeder Gateway in separate transactions (with locking)

### DIFF
--- a/packages/backend/src/core/collectors/FeederGatewayCollector.test.ts
+++ b/packages/backend/src/core/collectors/FeederGatewayCollector.test.ts
@@ -46,7 +46,7 @@ describe(FeederGatewayCollector.name, () => {
       ).toHaveBeenCalledTimes(1)
       expect(
         mockL2TransactionRepository.runInTransactionWithLockedTable
-      ).toHaveBeenCalledTimes(1)
+      ).toHaveBeenCalledTimes(5)
 
       for (const i of [1, 2, 3, 4, 5]) {
         expect(mockCollectForStateUpdate).toHaveBeenCalledWith(
@@ -88,7 +88,7 @@ describe(FeederGatewayCollector.name, () => {
 
       expect(
         mockL2TransactionRepository.runInTransactionWithLockedTable
-      ).toHaveBeenCalledTimes(1)
+      ).toHaveBeenCalledTimes(4)
 
       for (const i of [7, 8, 9, 10]) {
         expect(mockCollectForStateUpdate).toHaveBeenCalledWith(

--- a/packages/backend/src/core/collectors/FeederGatewayCollector.ts
+++ b/packages/backend/src/core/collectors/FeederGatewayCollector.ts
@@ -24,19 +24,19 @@ export class FeederGatewayCollector {
     const latestSyncedTransactionStateUpdateId =
       await this.l2TransactionRepository.findLatestStateUpdateId()
 
-    await this.l2TransactionRepository.runInTransactionWithLockedTable(
-      async (trx) => {
-        for (
-          let stateUpdateId = latestSyncedTransactionStateUpdateId
-            ? latestSyncedTransactionStateUpdateId + 1
-            : 1;
-          stateUpdateId <= latestStateUpdate.id;
-          stateUpdateId++
-        ) {
+    for (
+      let stateUpdateId = latestSyncedTransactionStateUpdateId
+        ? latestSyncedTransactionStateUpdateId + 1
+        : 1;
+      stateUpdateId <= latestStateUpdate.id;
+      stateUpdateId++
+    ) {
+      await this.l2TransactionRepository.runInTransactionWithLockedTable(
+        async (trx) => {
           await this.collectForStateUpdate(stateUpdateId, trx)
         }
-      }
-    )
+      )
+    }
   }
 
   async collectForStateUpdate(stateUpdateId: number, trx: Knex.Transaction) {


### PR DESCRIPTION
This is because we want to commit and not lock the table for longer than necessary