### PR TITLE
Remove spotlight article

### DIFF
--- a/packages/frontend/src/view/pages/home/HomePage.tsx
+++ b/packages/frontend/src/view/pages/home/HomePage.tsx
@@ -71,7 +71,7 @@ function HomePage(props: HomePageProps) {
             />
             {props.tutorials.length > 0 && (
               <HomeTutorials
-                tutorials={props.tutorials.slice(0, MAX_TUTORIALS )}
+                tutorials={props.tutorials.slice(0, MAX_TUTORIALS)}
                 showViewAll={showViewAllTutorials}
                 className="hidden xl:flex"
               />

--- a/packages/frontend/src/view/pages/home/HomePage.tsx
+++ b/packages/frontend/src/view/pages/home/HomePage.tsx
@@ -41,10 +41,10 @@ export function renderHomePage(props: HomePageProps) {
   return reactToHtml(<HomePage {...props} />)
 }
 
-const MAX_TUTORIALS = 3
+const MAX_TUTORIALS = 2
 
 function HomePage(props: HomePageProps) {
-  const showViewAllTutorials = props.tutorials.length > 3
+  const showViewAllTutorials = props.tutorials.length > 2
 
   return (
     <Page
@@ -71,7 +71,7 @@ function HomePage(props: HomePageProps) {
             />
             {props.tutorials.length > 0 && (
               <HomeTutorials
-                tutorials={props.tutorials.slice(0, MAX_TUTORIALS - 1)}
+                tutorials={props.tutorials.slice(0, MAX_TUTORIALS )}
                 showViewAll={showViewAllTutorials}
                 className="hidden xl:flex"
               />

--- a/packages/frontend/src/view/pages/home/HomePage.tsx
+++ b/packages/frontend/src/view/pages/home/HomePage.tsx
@@ -20,7 +20,6 @@ import {
   OFFER_TABLE_PROPS,
   STATE_UPDATE_TABLE_PROPS,
 } from './common'
-import { HomeSpotlightArticle } from './components/HomeSpotlightArticle'
 import {
   HomeStateUpdateEntry,
   HomeStateUpdatesTable,
@@ -46,7 +45,6 @@ const MAX_TUTORIALS = 3
 
 function HomePage(props: HomePageProps) {
   const showViewAllTutorials = props.tutorials.length > 3
-  const lastTutorial = props.tutorials[MAX_TUTORIALS - 1]
 
   return (
     <Page
@@ -85,12 +83,6 @@ function HomePage(props: HomePageProps) {
               tutorials={props.tutorials.slice(0, MAX_TUTORIALS)}
               showViewAll={showViewAllTutorials}
               className="xl:hidden"
-            />
-          )}
-          {lastTutorial && (
-            <HomeSpotlightArticle
-              spotlightArticle={lastTutorial}
-              className="hidden xl:grid"
             />
           )}
         </div>

--- a/packages/frontend/src/view/pages/home/HomePage.tsx
+++ b/packages/frontend/src/view/pages/home/HomePage.tsx
@@ -44,7 +44,7 @@ export function renderHomePage(props: HomePageProps) {
 const MAX_TUTORIALS = 2
 
 function HomePage(props: HomePageProps) {
-  const showViewAllTutorials = props.tutorials.length > 2
+  const showViewAllTutorials = props.tutorials.length > MAX_TUTORIALS
 
   return (
     <Page


### PR DESCRIPTION
The size of the spotlight component is too big for the content, and we need to rethink if it even makes sense to show the tutorial there. 