### PR TITLE
Fix forced withdrawal description

### DIFF
--- a/packages/frontend/src/view/pages/forced-actions/components/common.tsx
+++ b/packages/frontend/src/view/pages/forced-actions/components/common.tsx
@@ -7,7 +7,7 @@ const getWithdrawalInstructions = () => [
     Using this form you request a withdrawal of your funds. This is achieved
     through a mechanism called{' '}
     <Link href="https://docs.starkware.co/starkex/perpetual/perpetual-trading-forced-withdrawal-and-forced-trade.html#forced_withdrawal">
-      forced withdrawals
+      forced trades
     </Link>
     . Note that you can only withdraw USDC, so to fully exit all funds you
     should first close all open positions.


### PR DESCRIPTION
The forced withdrawal description in the code was incorrect. It has been updated to correctly refer to forced trades instead of forced withdrawals.